### PR TITLE
feat: support fallback to fstatat64 when statx is not available on Linux

### DIFF
--- a/monoio/src/fs/metadata/unix.rs
+++ b/monoio/src/fs/metadata/unix.rs
@@ -74,6 +74,16 @@ impl From<libc::statx> for FileAttr {
     }
 }
 
+#[cfg(target_os = "linux")]
+impl From<libc::stat64> for FileAttr {
+    fn from(value: libc::stat64) -> Self {
+        Self {
+            stat: value,
+            statx_extra_fields: None,
+        }
+    }
+}
+
 #[cfg(target_os = "macos")]
 impl From<libc::stat> for FileAttr {
     fn from(stat: libc::stat) -> Self {

--- a/monoio/tests/async_write_rent_boxed.rs
+++ b/monoio/tests/async_write_rent_boxed.rs
@@ -81,19 +81,13 @@ impl AsyncWriteRent for ErrorWriter {
         &mut self,
         _buf: T,
     ) -> impl std::future::Future<Output = monoio::BufResult<usize, T>> {
-        std::future::ready((
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "fail")),
-            _buf,
-        ))
+        std::future::ready((Err(std::io::Error::other("fail")), _buf))
     }
     fn writev<T: monoio::buf::IoVecBuf>(
         &mut self,
         _buf_vec: T,
     ) -> impl std::future::Future<Output = monoio::BufResult<usize, T>> {
-        std::future::ready((
-            Err(std::io::Error::new(std::io::ErrorKind::Other, "fail")),
-            _buf_vec,
-        ))
+        std::future::ready((Err(std::io::Error::other("fail")), _buf_vec))
     }
     fn flush(&mut self) -> impl std::future::Future<Output = std::io::Result<()>> {
         std::future::ready(Ok(()))

--- a/monoio/tests/async_write_rent_cursor.rs
+++ b/monoio/tests/async_write_rent_cursor.rs
@@ -57,7 +57,7 @@ async fn test_cursor_mut_vec() {
 
 #[monoio::test_all]
 async fn test_cursor_mut_slice() {
-    let mut data = vec![0u8; 32];
+    let mut data = [0u8; 32];
     {
         let mut cursor = Cursor::new(&mut data[..]);
 
@@ -137,7 +137,7 @@ async fn test_cursor_vectored_write() {
 // Test vectored writes with fixed-size buffers
 #[monoio::test_all]
 async fn test_cursor_vectored_write_fixed_size() {
-    let mut data = vec![0u8; 32];
+    let mut data = [0u8; 32];
     {
         let mut cursor = Cursor::new(&mut data[..]);
 
@@ -172,7 +172,7 @@ async fn test_cursor_vectored_write_fixed_size() {
 // Test error conditions
 #[monoio::test_all]
 async fn test_cursor_error_conditions() {
-    let mut data = vec![0u8; 8];
+    let mut data = [0u8; 8];
     {
         let mut cursor = Cursor::new(&mut data[..]);
 

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -1,7 +1,6 @@
 use std::{
     io::Write,
     net::{IpAddr, SocketAddr},
-    sync::LazyLock,
     thread::sleep,
     time::Duration,
 };
@@ -110,7 +109,7 @@ async fn connect_timeout_dst() {
         };
 
         let res = monoio::select! {
-            a = connect => false,
+            _ = connect => false,
             _ = monoio::time::sleep(std::time::Duration::from_secs(1)) => { true }
         };
         assert!(res);
@@ -128,14 +127,14 @@ fn create_test_server() -> u16 {
     let addr = listener.local_addr().unwrap();
 
     // the listener will not be closed until the test is done
-    let handler = std::thread::spawn(move || {
+    let _ = std::thread::spawn(move || {
         for stream in listener.incoming() {
             match stream {
                 Ok(mut stream) => {
                     sleep(Duration::from_millis(200));
                     let _ = stream.write_all(b"test server response");
                 }
-                Err(e) => eprintln!("connection failed: {}", e),
+                Err(e) => eprintln!("connection failed: {e}"),
             }
         }
     });
@@ -149,7 +148,7 @@ async fn cancel_read() {
 
     let server_port = create_test_server();
 
-    let mut s = TcpStream::connect(format!("127.0.0.1:{}", server_port))
+    let mut s = TcpStream::connect(format!("127.0.0.1:{server_port}"))
         .await
         .unwrap();
     let buf = vec![0; 20];
@@ -172,7 +171,7 @@ async fn cancel_select() {
 
     let server_port = create_test_server();
 
-    let mut s = TcpStream::connect(format!("127.0.0.1:{}", server_port))
+    let mut s = TcpStream::connect(format!("127.0.0.1:{server_port}"))
         .await
         .unwrap();
     let buf = vec![0; 20];


### PR DESCRIPTION
This PR basically support fallback to fstat64 when statx is not available on Linux.

Change to do the raw syscall of `statx`, which does not have requirements of libc, if this syscall failed with `ENOSYS` then fallback to the `fstatat64`