### PR TITLE
fix: remove fxhash to pass cargo audit

### DIFF
--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.2.4"
 monoio-macros = { version = "0.1.0", path = "../monoio-macros", optional = true }
 
 auto-const-array = "0.2"
-fxhash = "0.2"
+rustc-hash = "2.0"
 libc = "0.2"
 pin-project-lite = "0.2"
 socket2 = { version = "0.5", features = ["all"] }

--- a/monoio/src/driver/thread.rs
+++ b/monoio/src/driver/thread.rs
@@ -3,9 +3,9 @@ use std::sync::LazyLock;
 use std::{sync::Mutex, task::Waker};
 
 use flume::Sender;
-use fxhash::FxHashMap;
 #[cfg(not(feature = "unstable"))]
 use once_cell::sync::Lazy as LazyLock;
+use rustc_hash::FxHashMap;
 
 use crate::driver::UnparkHandle;
 

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -21,8 +21,8 @@ use crate::{
 thread_local! {
     pub(crate) static DEFAULT_CTX: Context = Context {
         thread_id: crate::utils::thread_id::DEFAULT_THREAD_ID,
-        unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-        waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+        unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+        waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
         tasks: Default::default(),
         time_handle: None,
         blocking_handle: crate::blocking::BlockingHandle::Empty(crate::blocking::BlockingStrategy::Panic),
@@ -41,12 +41,12 @@ pub(crate) struct Context {
     /// Thread unpark handles
     #[cfg(feature = "sync")]
     pub(crate) unpark_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, crate::driver::UnparkHandle>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, crate::driver::UnparkHandle>>,
 
     /// Waker sender cache
     #[cfg(feature = "sync")]
     pub(crate) waker_sender_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
 
     /// Time Handle
     pub(crate) time_handle: Option<TimeHandle>,
@@ -63,8 +63,8 @@ impl Context {
 
         Self {
             thread_id,
-            unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-            waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+            unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+            waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
             tasks: TaskQueue::default(),
             time_handle: None,
             blocking_handle,


### PR DESCRIPTION
  Fix cargo audit security warning by replacing unmaintained fxhash

  Summary

  - Replace fxhash 0.2 with rustc-hash 2.0 to resolve RUSTSEC-2025-0057 security advisory
  - Update all imports and usage from fxhash::FxHashMap to rustc_hash::FxHashMap

  Background

  The fxhash crate version 0.2.1 is no longer maintained, triggering a security advisory (RUSTSEC-2025-0057) in cargo audit. The recommended
  replacement is rustc-hash, which provides the same FxHashMap type with identical API and performance characteristics.
