### PR TITLE
feat(!): make socket creation, bind, listen async

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+FROM mcr.microsoft.com/devcontainers/base:ubuntu-24.04
+
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        libssl-dev \
+        liburing-dev \
+        pkg-config \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER vscode
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --profile minimal
+
+ENV PATH="/home/vscode/.cargo/bin:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "monoio-dev",
+    "build": {
+        "dockerfile": "Dockerfile",
+        "context": ".."
+    },
+    "remoteUser": "vscode",
+    "containerEnv": {
+        "CARGO_TERM_COLOR": "always",
+        "CARGO_TARGET_DIR": "/tmp/monoio-target",
+        "RUST_BACKTRACE": "1"
+    },
+    "runArgs": [
+        "--ulimit",
+        "memlock=-1:-1",
+        "--security-opt",
+        "seccomp=unconfined"
+    ],
+    "postCreateCommand": "rustup toolchain install nightly --profile minimal && rustup default nightly && rustup component add --toolchain nightly rustfmt clippy rust-analyzer && cargo +nightly fetch"
+}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,9 +63,9 @@ jobs:
           x86_64-unknown-linux-gnu,
 #          i686-unknown-linux-gnu,
           aarch64-unknown-linux-gnu,
-          armv7-unknown-linux-gnueabihf,
+          # armv7-unknown-linux-gnueabihf,
           riscv64gc-unknown-linux-gnu, 
-          s390x-unknown-linux-gnu,
+          # s390x-unknown-linux-gnu,
           loongarch64-unknown-linux-gnu,
 #          mips64-unknown-linux-muslabi64,
 
@@ -86,12 +86,14 @@ jobs:
 #            os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
             os: ubuntu-latest
-          - target: armv7-unknown-linux-gnueabihf
-            os: ubuntu-latest
+          # Disable armv7 tests because the crate `io-uring` does provide prebuilt `sys.rs` for this arch.
+          # - target: armv7-unknown-linux-gnueabihf
+          #   os: ubuntu-latest
           - target: riscv64gc-unknown-linux-gnu 
             os: ubuntu-latest
-          - target: s390x-unknown-linux-gnu
-            os: ubuntu-latest
+            # Disable s390x tests because the crate `io-uring` does provide prebuilt `sys.rs` for this arch.
+          # - target: s390x-unknown-linux-gnu
+          #   os: ubuntu-latest
           - target: loongarch64-unknown-linux-gnu
             os: ubuntu-latest
 #          - target: mips64-unknown-linux-muslabi64

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use monoio::net::{TcpListener, TcpStream};
 
 #[monoio::main]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ use monoio::net::{TcpListener, TcpStream};
 
 #[monoio::main]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/examples/accept.rs
+++ b/examples/accept.rs
@@ -8,7 +8,7 @@ use monoio::net::TcpListener;
 
 #[monoio::main(driver = "fusion", enable_timer = true)]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
     monoio::spawn(async {
         loop {
             monoio::time::sleep(Duration::from_secs(1)).await;

--- a/examples/accept.rs
+++ b/examples/accept.rs
@@ -8,7 +8,7 @@ use monoio::net::TcpListener;
 
 #[monoio::main(driver = "fusion", enable_timer = true)]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:50002").await.unwrap();
     monoio::spawn(async {
         loop {
             monoio::time::sleep(Duration::from_secs(1)).await;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -11,7 +11,7 @@ use monoio::{
 #[monoio::main(driver = "fusion")]
 async fn main() {
     // tracing_subscriber::fmt().with_max_level(tracing::Level::TRACE).init();
-    let listener = TcpListener::bind("127.0.0.1:50002").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/examples/echo.rs
+++ b/examples/echo.rs
@@ -11,7 +11,7 @@ use monoio::{
 #[monoio::main(driver = "fusion")]
 async fn main() {
     // tracing_subscriber::fmt().with_max_level(tracing::Level::TRACE).init();
-    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/examples/echo_poll.rs
+++ b/examples/echo_poll.rs
@@ -13,7 +13,7 @@ use monoio::{
 
 #[monoio::main(driver = "fusion")]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/examples/echo_poll.rs
+++ b/examples/echo_poll.rs
@@ -13,7 +13,7 @@ use monoio::{
 
 #[monoio::main(driver = "fusion")]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:50002").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:50002").await.unwrap();
     println!("listening");
     loop {
         let incoming = listener.accept().await;

--- a/examples/echo_tfo.rs
+++ b/examples/echo_tfo.rs
@@ -9,7 +9,9 @@ use monoio::{
 async fn main() {
     let bind_addr = "127.0.0.1:11990".parse::<SocketAddr>().unwrap();
     let opts = monoio::net::ListenerOpts::default().tcp_fast_open(true);
-    let listener = TcpListener::bind_with_config(bind_addr, &opts).unwrap();
+    let listener = TcpListener::bind_with_config(bind_addr, &opts)
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
     let (tx, rx) = local_sync::oneshot::channel();
     monoio::spawn(async move {

--- a/examples/echo_tfo.rs
+++ b/examples/echo_tfo.rs
@@ -9,7 +9,7 @@ use monoio::{
 async fn main() {
     let bind_addr = "127.0.0.1:11990".parse::<SocketAddr>().unwrap();
     let opts = monoio::net::ListenerOpts::default().tcp_fast_open(true);
-    let listener = TcpListener::bind_with_config(bind_addr, &opts)
+    let listener = TcpListener::async_bind_with_config(bind_addr, &opts)
         .await
         .unwrap();
     let addr = listener.local_addr().unwrap();

--- a/examples/h2_server.rs
+++ b/examples/h2_server.rs
@@ -48,7 +48,7 @@ async fn handle_request(
 
 #[monoio::main(threads = 2)]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:5928").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:5928").await.unwrap();
     println!("listening on {:?}", listener.local_addr());
 
     loop {

--- a/examples/h2_server.rs
+++ b/examples/h2_server.rs
@@ -48,7 +48,7 @@ async fn handle_request(
 
 #[monoio::main(threads = 2)]
 async fn main() {
-    let listener = TcpListener::bind("127.0.0.1:5928").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:5928").await.unwrap();
     println!("listening on {:?}", listener.local_addr());
 
     loop {

--- a/examples/hyper_server.rs
+++ b/examples/hyper_server.rs
@@ -17,7 +17,7 @@ where
     E: std::error::Error + 'static + Send + Sync,
     A: Into<SocketAddr>,
 {
-    let listener = TcpListener::bind(addr.into())?;
+    let listener = TcpListener::bind(addr.into()).await?;
     loop {
         let (stream, _) = listener.accept().await?;
         let stream_poll = monoio_compat::hyper::MonoioIo::new(stream.into_poll_io()?);

--- a/examples/hyper_server.rs
+++ b/examples/hyper_server.rs
@@ -17,7 +17,7 @@ where
     E: std::error::Error + 'static + Send + Sync,
     A: Into<SocketAddr>,
 {
-    let listener = TcpListener::bind(addr.into()).await?;
+    let listener = TcpListener::async_bind(addr.into()).await?;
     loop {
         let (stream, _) = listener.accept().await?;
         let stream_poll = monoio_compat::hyper::MonoioIo::new(stream.into_poll_io()?);

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -11,6 +11,7 @@ const TARGET_ADDRESS: &str = "127.0.0.1:50006";
 #[monoio::main(entries = 512, timer_enabled = false)]
 async fn main() {
     let listener = TcpListener::bind(LISTEN_ADDRESS)
+        .await
         .unwrap_or_else(|_| panic!("[Server] Unable to bind to {LISTEN_ADDRESS}"));
     loop {
         if let Ok((in_conn, _addr)) = listener.accept().await {

--- a/examples/proxy.rs
+++ b/examples/proxy.rs
@@ -10,7 +10,7 @@ const TARGET_ADDRESS: &str = "127.0.0.1:50006";
 
 #[monoio::main(entries = 512, timer_enabled = false)]
 async fn main() {
-    let listener = TcpListener::bind(LISTEN_ADDRESS)
+    let listener = TcpListener::async_bind(LISTEN_ADDRESS)
         .await
         .unwrap_or_else(|_| panic!("[Server] Unable to bind to {LISTEN_ADDRESS}"));
     loop {

--- a/examples/tcp_legacy.rs
+++ b/examples/tcp_legacy.rs
@@ -37,6 +37,7 @@ where
     let server_thread = std::thread::spawn(|| {
         monoio::start::<D, _>(async move {
             let listener = TcpListener::bind(ADDRESS)
+                .await
                 .unwrap_or_else(|_| panic!("[Server] Unable to bind to {ADDRESS}"));
             println!("[Server] Bind ready");
             drop(rx);

--- a/examples/tcp_legacy.rs
+++ b/examples/tcp_legacy.rs
@@ -36,7 +36,7 @@ where
 
     let server_thread = std::thread::spawn(|| {
         monoio::start::<D, _>(async move {
-            let listener = TcpListener::bind(ADDRESS)
+            let listener = TcpListener::async_bind(ADDRESS)
                 .await
                 .unwrap_or_else(|_| panic!("[Server] Unable to bind to {ADDRESS}"));
             println!("[Server] Bind ready");

--- a/examples/timer_select.rs
+++ b/examples/timer_select.rs
@@ -43,7 +43,7 @@ async fn main() {
     // a good way.
     let canceller = Canceller::new();
     let timeout_fut = monoio::time::sleep(Duration::from_millis(100));
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let mut io_fut = pin!(listener.cancelable_accept(canceller.handle()));
 
     monoio::select! {

--- a/examples/timer_select.rs
+++ b/examples/timer_select.rs
@@ -43,7 +43,7 @@ async fn main() {
     // a good way.
     let canceller = Canceller::new();
     let timeout_fut = monoio::time::sleep(Duration::from_millis(100));
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:0").await.unwrap();
     let mut io_fut = pin!(listener.cancelable_accept(canceller.handle()));
 
     monoio::select! {

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -25,7 +25,7 @@ async fn main() {
     });
 
     std::fs::remove_file(ADDRESS).ok();
-    let listener = UnixListener::bind(ADDRESS).unwrap();
+    let listener = UnixListener::bind(ADDRESS).await.unwrap();
     println!("listening on {ADDRESS:?}");
     drop(rx);
     let (mut conn, addr) = listener.accept().await.unwrap();

--- a/examples/uds.rs
+++ b/examples/uds.rs
@@ -25,7 +25,7 @@ async fn main() {
     });
 
     std::fs::remove_file(ADDRESS).ok();
-    let listener = UnixListener::bind(ADDRESS).await.unwrap();
+    let listener = UnixListener::async_bind(ADDRESS).await.unwrap();
     println!("listening on {ADDRESS:?}");
     drop(rx);
     let (mut conn, addr) = listener.accept().await.unwrap();

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -56,7 +56,7 @@ nix = { version = "0.29", features = [
 ], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
-io-uring = { version = "0.6", optional = true }
+io-uring = { version = "0.7", optional = true }
 
 [dev-dependencies]
 futures = "0.3"
@@ -82,6 +82,10 @@ unlinkat = []
 renameat = []
 # symlinkat op(requires kernel 5.15+)
 symlinkat = []
+# listen op(requires kernel 6.11+)
+listen = []
+# bind op(requires kernel 6.11+)
+bind = []
 # enable `async main` macros support
 macros = ["monoio-macros"]
 # allow waker to be sent across threads

--- a/monoio/Cargo.toml
+++ b/monoio/Cargo.toml
@@ -15,7 +15,7 @@ version = "0.2.4"
 monoio-macros = { version = "0.1.0", path = "../monoio-macros", optional = true }
 
 auto-const-array = "0.2"
-fxhash = "0.2"
+rustc-hash = "2.1"
 libc = "0.2"
 pin-project-lite = "0.2"
 socket2 = { version = "0.5", features = ["all"] }
@@ -49,7 +49,11 @@ windows-sys = { version = "0.48.0", features = [
 
 # unix dependencies
 [target.'cfg(unix)'.dependencies]
-nix = { version = "0.29", features = ["sched", "ucontext", "process"], optional = true }
+nix = { version = "0.29", features = [
+    "sched",
+    "ucontext",
+    "process",
+], optional = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 io-uring = { version = "0.6", optional = true }

--- a/monoio/src/driver/op.rs
+++ b/monoio/src/driver/op.rs
@@ -21,6 +21,15 @@ mod send;
 #[cfg(unix)]
 mod statx;
 
+#[cfg(unix)]
+mod socket;
+
+#[cfg(feature = "bind")]
+mod bind;
+
+#[cfg(feature = "listen")]
+mod listen;
+
 #[cfg(feature = "mkdirat")]
 mod mkdir;
 

--- a/monoio/src/driver/op/bind.rs
+++ b/monoio/src/driver/op/bind.rs
@@ -1,0 +1,45 @@
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use crate::driver::op::MaybeFd;
+use crate::driver::op::{Op, OpAble};
+
+pub(crate) struct Bind {
+    pub(crate) socket: socket2::Socket,
+    pub(crate) address: socket2::SockAddr,
+}
+
+impl Op<Bind> {
+    pub(crate) fn bind(
+        socket: socket2::Socket,
+        address: socket2::SockAddr,
+    ) -> std::io::Result<Self> {
+        Op::submit_with(Bind { socket, address })
+    }
+}
+
+impl OpAble for Bind {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        use std::os::fd::AsRawFd;
+
+        use io_uring::{opcode, types};
+
+        opcode::Bind::new(
+            types::Fd(self.socket.as_raw_fd()),
+            self.address.as_ptr(),
+            self.address.len(),
+        )
+        .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[inline]
+    fn legacy_interest(&self) -> Option<(super::super::ready::Direction, usize)> {
+        None
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
+        use std::os::fd::AsRawFd;
+        crate::syscall!(bind@NON_FD(self.socket.as_raw_fd(), self.address.as_ptr(), self.address.len()))
+    }
+}

--- a/monoio/src/driver/op/listen.rs
+++ b/monoio/src/driver/op/listen.rs
@@ -1,0 +1,36 @@
+use crate::driver::op::{Op, OpAble};
+
+pub(crate) struct Listen {
+    pub(crate) socket: socket2::Socket,
+    pub(crate) backlog: i32,
+}
+
+impl Op<Listen> {
+    pub(crate) fn listen(socket: socket2::Socket, backlog: i32) -> std::io::Result<Self> {
+        Op::submit_with(Listen { socket, backlog })
+    }
+}
+
+impl OpAble for Listen {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        use std::os::fd::AsRawFd;
+
+        use io_uring::{opcode, types};
+
+        opcode::Listen::new(types::Fd(self.socket.as_raw_fd()), self.backlog).build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[inline]
+    fn legacy_interest(&self) -> Option<(super::super::ready::Direction, usize)> {
+        None
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> std::io::Result<super::MaybeFd> {
+        use std::os::fd::AsRawFd;
+
+        crate::syscall!(listen@NON_FD(self.socket.as_raw_fd(), self.backlog))
+    }
+}

--- a/monoio/src/driver/op/recv.rs
+++ b/monoio/src/driver/op/recv.rs
@@ -250,7 +250,7 @@ impl<T: IoBufMut> OpAble for RecvMsg<T> {
                 fd,
                 SIO_GET_EXTENSION_FUNCTION_POINTER,
                 &WSAID_WSARECVMSG as *const _ as *const std::ffi::c_void,
-                std::mem::size_of::<GUID> as usize as u32,
+                std::mem::size_of::<GUID> as *const () as usize as u32,
                 &mut wsa_recv_msg as *mut _ as *mut std::ffi::c_void,
                 std::mem::size_of::<LPFN_WSARECVMSG>() as _,
                 &mut dw_bytes,

--- a/monoio/src/driver/op/recv.rs
+++ b/monoio/src/driver/op/recv.rs
@@ -250,7 +250,7 @@ impl<T: IoBufMut> OpAble for RecvMsg<T> {
                 fd,
                 SIO_GET_EXTENSION_FUNCTION_POINTER,
                 &WSAID_WSARECVMSG as *const _ as *const std::ffi::c_void,
-                std::mem::size_of::<GUID> as *const () as usize as u32,
+                std::mem::size_of::<GUID>() as u32,
                 &mut wsa_recv_msg as *mut _ as *mut std::ffi::c_void,
                 std::mem::size_of::<LPFN_WSARECVMSG>() as _,
                 &mut dw_bytes,

--- a/monoio/src/driver/op/socket.rs
+++ b/monoio/src/driver/op/socket.rs
@@ -1,0 +1,55 @@
+#[cfg(any(feature = "legacy", feature = "poll-io"))]
+use crate::driver::op::MaybeFd;
+use crate::driver::op::{Op, OpAble};
+
+pub(crate) struct Socket {
+    domain: socket2::Domain,
+    ty: socket2::Type,
+    protocol: Option<socket2::Protocol>,
+}
+
+impl Op<Socket> {
+    pub(crate) fn socket(
+        domain: socket2::Domain,
+        ty: socket2::Type,
+        protocol: Option<socket2::Protocol>,
+    ) -> std::io::Result<Self> {
+        // Follow the `socket2`'s behavior
+        #[cfg(target_os = "linux")]
+        let ty = ty.cloexec();
+
+        Op::submit_with(Socket {
+            domain,
+            ty,
+            protocol,
+        })
+    }
+}
+
+impl OpAble for Socket {
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    const RET_IS_FD: bool = true;
+
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        use io_uring::opcode;
+
+        opcode::Socket::new(
+            self.domain.into(),
+            self.ty.into(),
+            self.protocol.map_or(0, |p| p.into()),
+        )
+        .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[inline]
+    fn legacy_interest(&self) -> Option<(super::super::ready::Direction, usize)> {
+        None
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
+        crate::syscall!(socket@FD(self.domain.into(), self.ty.into(), self.protocol.map_or(0, |p| p.into())))
+    }
+}

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -524,10 +524,10 @@ impl Drop for Inner {
         #[allow(unreachable_patterns)]
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
-            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..)) => {
-                if super::op::Op::close(fd).is_err() {
-                    let _ = unsafe { std::fs::File::from_raw_fd(fd) };
-                };
+            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..))
+                if super::op::Op::close(fd).is_err() =>
+            {
+                let _ = unsafe { std::fs::File::from_raw_fd(fd) };
             }
             #[cfg(feature = "legacy")]
             State::Legacy(idx) => drop_legacy(fd, *idx),

--- a/monoio/src/driver/thread.rs
+++ b/monoio/src/driver/thread.rs
@@ -3,9 +3,9 @@ use std::sync::LazyLock;
 use std::{sync::Mutex, task::Waker};
 
 use flume::Sender;
-use fxhash::FxHashMap;
 #[cfg(not(feature = "unstable"))]
 use once_cell::sync::Lazy as LazyLock;
+use rustc_hash::FxHashMap;
 
 use crate::driver::UnparkHandle;
 

--- a/monoio/src/net/mod.rs
+++ b/monoio/src/net/mod.rs
@@ -42,7 +42,7 @@ pub(crate) async fn new_socket(
         target_os = "netbsd",
         target_os = "openbsd"
     ))]
-    let socket_type = socket_type | libc::SOCK_NONBLOCK | libc::SOCK_CLOEXEC;
+    let socket_type = socket_type.cloexec().nonblocking();
 
     #[cfg(target_os = "linux")]
     let socket_type = {

--- a/monoio/src/net/tcp/listener.rs
+++ b/monoio/src/net/tcp/listener.rs
@@ -32,6 +32,29 @@ pub struct TcpListener {
 }
 
 impl TcpListener {
+    fn apply_listener_opts(sys_listener: &socket2::Socket, opts: &ListenerOpts) -> io::Result<()> {
+        #[cfg(unix)]
+        if opts.reuse_port {
+            sys_listener.set_reuse_port(true)?;
+        }
+        if opts.reuse_addr {
+            sys_listener.set_reuse_address(true)?;
+        }
+        if let Some(send_buf_size) = opts.send_buf_size {
+            sys_listener.set_send_buffer_size(send_buf_size)?;
+        }
+        if let Some(recv_buf_size) = opts.recv_buf_size {
+            sys_listener.set_recv_buffer_size(recv_buf_size)?;
+        }
+        if opts.tcp_fast_open {
+            #[cfg(any(target_os = "linux", target_os = "android"))]
+            super::tfo::set_tcp_fastopen(sys_listener, opts.backlog)?;
+            #[cfg(any(target_os = "ios", target_os = "macos"))]
+            let _ = super::tfo::set_tcp_fastopen_force_enable(sys_listener);
+        }
+        Ok(())
+    }
+
     #[allow(unreachable_code, clippy::diverging_sub_expression, unused_variables)]
     pub(crate) fn from_shared_fd(fd: SharedFd) -> Self {
         #[cfg(unix)]
@@ -46,7 +69,44 @@ impl TcpListener {
     }
 
     /// Bind to address with config
-    pub async fn bind_with_config<A: ToSocketAddrs>(
+    pub fn bind_with_config<A: ToSocketAddrs>(addr: A, opts: &ListenerOpts) -> io::Result<Self> {
+        let addr = addr
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| io::Error::other("empty address"))?;
+
+        let domain = if addr.is_ipv6() {
+            socket2::Domain::IPV6
+        } else {
+            socket2::Domain::IPV4
+        };
+        let sys_listener =
+            socket2::Socket::new(domain, socket2::Type::STREAM, Some(socket2::Protocol::TCP))?;
+
+        #[cfg(feature = "legacy")]
+        Self::set_non_blocking(&sys_listener)?;
+
+        let addr = socket2::SockAddr::from(addr);
+        Self::apply_listener_opts(&sys_listener, opts)?;
+        sys_listener.bind(&addr)?;
+        sys_listener.listen(opts.backlog)?;
+
+        #[cfg(any(target_os = "ios", target_os = "macos"))]
+        if opts.tcp_fast_open {
+            super::tfo::set_tcp_fastopen(&sys_listener)?;
+        }
+
+        #[cfg(unix)]
+        let fd = sys_listener.into_raw_fd();
+
+        #[cfg(windows)]
+        let fd = sys_listener.into_raw_socket();
+
+        Ok(Self::from_shared_fd(SharedFd::new::<false>(fd)?))
+    }
+
+    /// Bind to address with config asynchronously
+    pub async fn async_bind_with_config<A: ToSocketAddrs>(
         addr: A,
         opts: &ListenerOpts,
     ) -> io::Result<Self> {
@@ -79,25 +139,7 @@ impl TcpListener {
         Self::set_non_blocking(&sys_listener)?;
 
         let addr = socket2::SockAddr::from(addr);
-        #[cfg(unix)]
-        if opts.reuse_port {
-            sys_listener.set_reuse_port(true)?;
-        }
-        if opts.reuse_addr {
-            sys_listener.set_reuse_address(true)?;
-        }
-        if let Some(send_buf_size) = opts.send_buf_size {
-            sys_listener.set_send_buffer_size(send_buf_size)?;
-        }
-        if let Some(recv_buf_size) = opts.recv_buf_size {
-            sys_listener.set_recv_buffer_size(recv_buf_size)?;
-        }
-        if opts.tcp_fast_open {
-            #[cfg(any(target_os = "linux", target_os = "android"))]
-            super::tfo::set_tcp_fastopen(&sys_listener, opts.backlog)?;
-            #[cfg(any(target_os = "ios", target_os = "macos"))]
-            let _ = super::tfo::set_tcp_fastopen_force_enable(&sys_listener);
-        }
+        Self::apply_listener_opts(&sys_listener, opts)?;
 
         #[cfg(feature = "bind")]
         let sys_listener = {
@@ -134,9 +176,15 @@ impl TcpListener {
     }
 
     /// Bind to address
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         const DEFAULT_CFG: ListenerOpts = ListenerOpts::new();
-        Self::bind_with_config(addr, &DEFAULT_CFG).await
+        Self::bind_with_config(addr, &DEFAULT_CFG)
+    }
+
+    /// Bind to address asynchronously
+    pub async fn async_bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+        const DEFAULT_CFG: ListenerOpts = ListenerOpts::new();
+        Self::async_bind_with_config(addr, &DEFAULT_CFG).await
     }
 
     /// Accept

--- a/monoio/src/net/udp.rs
+++ b/monoio/src/net/udp.rs
@@ -48,7 +48,7 @@ impl UdpSocket {
     }
 
     /// Creates a UDP socket from the given address.
-    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let addr = addr
             .to_socket_addrs()?
             .next()
@@ -58,12 +58,42 @@ impl UdpSocket {
         } else {
             socket2::Domain::IPV4
         };
+
+        #[cfg(unix)]
+        let socket = {
+            let completion =
+                Op::socket(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?.await;
+            let fd = completion.meta.result?.into_inner();
+            unsafe { socket2::Socket::from_raw_fd(fd as _) }
+        };
+
+        #[cfg(windows)]
         let socket =
             socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+
         #[cfg(feature = "legacy")]
         Self::set_non_blocking(&socket)?;
 
         let addr = socket2::SockAddr::from(addr);
+
+        #[cfg(feature = "bind")]
+        let socket = {
+            let completion = Op::bind(socket, addr)?.await;
+            match completion.meta.result {
+                Ok(_) => completion.data.socket,
+                // Kernal may not support io_uring bind operation, in this case, we will fallback to
+                // the raw bind.
+                Err(ref err) if err.raw_os_error() == Some(libc::EINVAL) => {
+                    let socket = completion.data.socket;
+                    let addr = completion.data.address;
+                    socket.bind(&addr)?;
+                    socket
+                }
+                Err(err) => return Err(err),
+            }
+        };
+
+        #[cfg(not(feature = "bind"))]
         socket.bind(&addr)?;
 
         #[cfg(unix)]

--- a/monoio/src/net/udp.rs
+++ b/monoio/src/net/udp.rs
@@ -79,18 +79,8 @@ impl UdpSocket {
         #[cfg(feature = "bind")]
         let socket = {
             let completion = Op::bind(socket, addr)?.await;
-            match completion.meta.result {
-                Ok(_) => completion.data.socket,
-                // Kernal may not support io_uring bind operation, in this case, we will fallback to
-                // the raw bind.
-                Err(ref err) if err.raw_os_error() == Some(libc::EINVAL) => {
-                    let socket = completion.data.socket;
-                    let addr = completion.data.address;
-                    socket.bind(&addr)?;
-                    socket
-                }
-                Err(err) => return Err(err),
-            }
+            completion.meta.result?;
+            completion.data.socket
         };
 
         #[cfg(not(feature = "bind"))]

--- a/monoio/src/net/udp.rs
+++ b/monoio/src/net/udp.rs
@@ -48,7 +48,34 @@ impl UdpSocket {
     }
 
     /// Creates a UDP socket from the given address.
-    pub async fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+    pub fn bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
+        let addr = addr
+            .to_socket_addrs()?
+            .next()
+            .ok_or_else(|| io::Error::other("empty address"))?;
+        let domain = if addr.is_ipv6() {
+            socket2::Domain::IPV6
+        } else {
+            socket2::Domain::IPV4
+        };
+        let socket =
+            socket2::Socket::new(domain, socket2::Type::DGRAM, Some(socket2::Protocol::UDP))?;
+        #[cfg(feature = "legacy")]
+        Self::set_non_blocking(&socket)?;
+
+        let addr = socket2::SockAddr::from(addr);
+        socket.bind(&addr)?;
+
+        #[cfg(unix)]
+        let fd = socket.into_raw_fd();
+        #[cfg(windows)]
+        let fd = socket.into_raw_socket();
+
+        Ok(Self::from_shared_fd(SharedFd::new::<false>(fd)?))
+    }
+
+    /// Creates a UDP socket from the given address asynchronously.
+    pub async fn async_bind<A: ToSocketAddrs>(addr: A) -> io::Result<Self> {
         let addr = addr
             .to_socket_addrs()?
             .next()

--- a/monoio/src/net/unix/datagram/mod.rs
+++ b/monoio/src/net/unix/datagram/mod.rs
@@ -62,7 +62,7 @@ impl UnixDatagram {
         sockaddr: libc::sockaddr_un,
         socklen: libc::socklen_t,
     ) -> io::Result<Self> {
-        let socket = new_socket(libc::AF_UNIX, libc::SOCK_DGRAM)?;
+        let socket = new_socket(socket2::Domain::UNIX, socket2::Type::DGRAM).await?;
         let op = Op::connect_unix(SharedFd::new::<false>(socket)?, sockaddr, socklen)?;
         let completion = op.await;
         completion.meta.result?;

--- a/monoio/src/net/unix/listener.rs
+++ b/monoio/src/net/unix/listener.rs
@@ -44,7 +44,10 @@ impl UnixListener {
             // TODO: properly handle this. Warn?
             // this seems to cause an error on current (>6.x) kernels:
             // sys_listener.set_reuse_port(true)?;
-            panic!("Unix sock does not support reuse port!")
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Unix sockets do not support SO_REUSEPORT",
+            ));
         }
         if config.reuse_addr {
             sys_listener.set_reuse_address(true)?;

--- a/monoio/src/net/unix/listener.rs
+++ b/monoio/src/net/unix/listener.rs
@@ -19,6 +19,31 @@ pub struct UnixListener {
 }
 
 impl UnixListener {
+    fn apply_listener_config(
+        sys_listener: &socket2::Socket,
+        config: &ListenerOpts,
+    ) -> io::Result<()> {
+        if config.reuse_port {
+            // Unix domain socket does not support SO_REUSEPORT.
+            return Err(io::Error::new(
+                io::ErrorKind::Unsupported,
+                "Unix sockets do not support SO_REUSEPORT",
+            ));
+        }
+
+        if config.reuse_addr {
+            sys_listener.set_reuse_address(true)?;
+        }
+        if let Some(send_buf_size) = config.send_buf_size {
+            sys_listener.set_send_buffer_size(send_buf_size)?;
+        }
+        if let Some(recv_buf_size) = config.recv_buf_size {
+            sys_listener.set_recv_buffer_size(recv_buf_size)?;
+        }
+
+        Ok(())
+    }
+
     pub(crate) fn from_shared_fd(fd: SharedFd) -> Self {
         let sys_listener = unsafe { std::os::unix::net::UnixListener::from_raw_fd(fd.raw_fd()) };
         Self {
@@ -29,7 +54,27 @@ impl UnixListener {
 
     /// Creates a new `UnixListener` bound to the specified socket with custom
     /// config.
-    pub async fn bind_with_config<P: AsRef<Path>>(
+    pub fn bind_with_config<P: AsRef<Path>>(
+        path: P,
+        config: &ListenerOpts,
+    ) -> io::Result<UnixListener> {
+        let sys_listener =
+            socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::STREAM, None)?;
+        let addr = socket2::SockAddr::unix(path)?;
+
+        Self::apply_listener_config(&sys_listener, config)?;
+
+        sys_listener.bind(&addr)?;
+        sys_listener.listen(config.backlog)?;
+
+        let fd = SharedFd::new::<false>(sys_listener.into_raw_fd())?;
+
+        Ok(Self::from_shared_fd(fd))
+    }
+
+    /// Creates a new `UnixListener` bound to the specified socket with custom
+    /// config asynchronously.
+    pub async fn async_bind_with_config<P: AsRef<Path>>(
         path: P,
         config: &ListenerOpts,
     ) -> io::Result<UnixListener> {
@@ -40,24 +85,7 @@ impl UnixListener {
         };
         let addr = socket2::SockAddr::unix(path)?;
 
-        if config.reuse_port {
-            // TODO: properly handle this. Warn?
-            // this seems to cause an error on current (>6.x) kernels:
-            // sys_listener.set_reuse_port(true)?;
-            return Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "Unix sockets do not support SO_REUSEPORT",
-            ));
-        }
-        if config.reuse_addr {
-            sys_listener.set_reuse_address(true)?;
-        }
-        if let Some(send_buf_size) = config.send_buf_size {
-            sys_listener.set_send_buffer_size(send_buf_size)?;
-        }
-        if let Some(recv_buf_size) = config.recv_buf_size {
-            sys_listener.set_recv_buffer_size(recv_buf_size)?;
-        }
+        Self::apply_listener_config(&sys_listener, config)?;
 
         #[cfg(feature = "bind")]
         let sys_listener = {
@@ -86,8 +114,14 @@ impl UnixListener {
 
     /// Creates a new `UnixListener` bound to the specified socket with default
     /// config.
-    pub async fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
-        Self::bind_with_config(path, &ListenerOpts::default().reuse_port(false)).await
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
+        Self::bind_with_config(path, &ListenerOpts::default().reuse_port(false))
+    }
+
+    /// Creates a new `UnixListener` bound to the specified socket with default
+    /// config asynchronously.
+    pub async fn async_bind<P: AsRef<Path>>(path: P) -> io::Result<UnixListener> {
+        Self::async_bind_with_config(path, &ListenerOpts::default().reuse_port(false)).await
     }
 
     /// Accept

--- a/monoio/src/net/unix/seq_packet/listener.rs
+++ b/monoio/src/net/unix/seq_packet/listener.rs
@@ -28,7 +28,6 @@ impl UnixSeqpacketListener {
         backlog: libc::c_int,
     ) -> io::Result<Self> {
         let addr = socket2::SockAddr::unix(path)?;
-        // let (addr, addr_len) = socket_addr(path.as_ref())?;
         let socket = new_socket(socket2::Domain::UNIX, socket2::Type::SEQPACKET).await?;
         let socket = unsafe { socket2::Socket::from_raw_fd(socket) };
 

--- a/monoio/src/net/unix/seq_packet/listener.rs
+++ b/monoio/src/net/unix/seq_packet/listener.rs
@@ -23,7 +23,26 @@ pub struct UnixSeqpacketListener {
 
 impl UnixSeqpacketListener {
     /// Creates a new `UnixSeqpacketListener` bound to the specified path with custom backlog
-    pub async fn bind_with_backlog<P: AsRef<Path>>(
+    pub fn bind_with_backlog<P: AsRef<Path>>(path: P, backlog: libc::c_int) -> io::Result<Self> {
+        let addr = socket2::SockAddr::unix(path)?;
+        let socket = socket2::Socket::new(socket2::Domain::UNIX, socket2::Type::SEQPACKET, None)?;
+
+        #[cfg(feature = "legacy")]
+        if crate::driver::op::is_legacy() {
+            socket.set_nonblocking(true)?;
+        }
+
+        socket.bind(&addr)?;
+        socket.listen(backlog)?;
+
+        Ok(Self {
+            fd: SharedFd::new::<false>(socket.into_raw_fd())?,
+        })
+    }
+
+    /// Creates a new `UnixSeqpacketListener` bound to the specified path with custom backlog
+    /// asynchronously.
+    pub async fn async_bind_with_backlog<P: AsRef<Path>>(
         path: P,
         backlog: libc::c_int,
     ) -> io::Result<Self> {
@@ -58,8 +77,15 @@ impl UnixSeqpacketListener {
 
     /// Creates a new `UnixSeqpacketListener` bound to the specified path with default backlog(128)
     #[inline]
-    pub async fn bind<P: AsRef<Path>>(path: P) -> io::Result<Self> {
-        Self::bind_with_backlog(path, DEFAULT_BACKLOG).await
+    pub fn bind<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Self::bind_with_backlog(path, DEFAULT_BACKLOG)
+    }
+
+    /// Creates a new `UnixSeqpacketListener` bound to the specified path with default backlog(128)
+    /// asynchronously.
+    #[inline]
+    pub async fn async_bind<P: AsRef<Path>>(path: P) -> io::Result<Self> {
+        Self::async_bind_with_backlog(path, DEFAULT_BACKLOG).await
     }
 
     /// Accept a UnixSeqpacket

--- a/monoio/src/net/unix/seq_packet/mod.rs
+++ b/monoio/src/net/unix/seq_packet/mod.rs
@@ -56,7 +56,7 @@ impl UnixSeqpacket {
         sockaddr: libc::sockaddr_un,
         socklen: libc::socklen_t,
     ) -> io::Result<Self> {
-        let socket = new_socket(libc::AF_UNIX, libc::SOCK_SEQPACKET)?;
+        let socket = new_socket(socket2::Domain::UNIX, socket2::Type::SEQPACKET).await?;
         let op = Op::connect_unix(SharedFd::new::<false>(socket)?, sockaddr, socklen)?;
         let completion = op.await;
         completion.meta.result?;

--- a/monoio/src/net/unix/socket_addr.rs
+++ b/monoio/src/net/unix/socket_addr.rs
@@ -36,7 +36,12 @@ impl SocketAddr {
             return AddressKind::Unnamed;
         }
         let len = self.socklen as usize - offset;
-        let path = unsafe { &*(&self.sockaddr.sun_path as *const [libc::c_char] as *const [u8]) };
+        let path = unsafe {
+            std::slice::from_raw_parts(
+                self.sockaddr.sun_path.as_ptr().cast(),
+                self.sockaddr.sun_path.len(),
+            )
+        };
 
         // macOS seems to return a len of 16 and a zeroed sun_path for unnamed addresses
         if len == 0 || (cfg!(not(any(target_os = "linux", target_os = "android"))) && path[0] == 0)

--- a/monoio/src/net/unix/stream.rs
+++ b/monoio/src/net/unix/stream.rs
@@ -51,7 +51,7 @@ impl UnixStream {
         sockaddr: libc::sockaddr_un,
         socklen: libc::socklen_t,
     ) -> io::Result<Self> {
-        let socket = new_socket(libc::AF_UNIX, libc::SOCK_STREAM)?;
+        let socket = new_socket(socket2::Domain::UNIX, socket2::Type::STREAM).await?;
         let op = Op::connect_unix(SharedFd::new::<false>(socket)?, sockaddr, socklen)?;
         let completion = op.await;
         completion.meta.result?;

--- a/monoio/src/runtime.rs
+++ b/monoio/src/runtime.rs
@@ -21,8 +21,8 @@ use crate::{
 thread_local! {
     pub(crate) static DEFAULT_CTX: Context = Context {
         thread_id: crate::utils::thread_id::DEFAULT_THREAD_ID,
-        unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-        waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+        unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+        waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
         tasks: Default::default(),
         time_handle: None,
         blocking_handle: crate::blocking::BlockingHandle::Empty(crate::blocking::BlockingStrategy::Panic),
@@ -41,12 +41,12 @@ pub(crate) struct Context {
     /// Thread unpark handles
     #[cfg(feature = "sync")]
     pub(crate) unpark_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, crate::driver::UnparkHandle>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, crate::driver::UnparkHandle>>,
 
     /// Waker sender cache
     #[cfg(feature = "sync")]
     pub(crate) waker_sender_cache:
-        std::cell::RefCell<fxhash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
+        std::cell::RefCell<rustc_hash::FxHashMap<usize, flume::Sender<std::task::Waker>>>,
 
     /// Time Handle
     pub(crate) time_handle: Option<TimeHandle>,
@@ -63,8 +63,8 @@ impl Context {
 
         Self {
             thread_id,
-            unpark_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
-            waker_sender_cache: std::cell::RefCell::new(fxhash::FxHashMap::default()),
+            unpark_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
+            waker_sender_cache: std::cell::RefCell::new(rustc_hash::FxHashMap::default()),
             tasks: TaskQueue::default(),
             time_handle: None,
             blocking_handle,

--- a/monoio/tests/buf_writter.rs
+++ b/monoio/tests/buf_writter.rs
@@ -5,7 +5,7 @@ use monoio::{
 
 #[monoio::test_all]
 async fn ensure_buf_writter_write_properly() {
-    let srv = TcpListener::bind("127.0.0.1:0").unwrap();
+    let srv = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = srv.local_addr().unwrap();
 
     monoio::spawn(async move {

--- a/monoio/tests/buf_writter.rs
+++ b/monoio/tests/buf_writter.rs
@@ -5,7 +5,7 @@ use monoio::{
 
 #[monoio::test_all]
 async fn ensure_buf_writter_write_properly() {
-    let srv = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let srv = TcpListener::async_bind("127.0.0.1:0").await.unwrap();
     let addr = srv.local_addr().unwrap();
 
     monoio::spawn(async move {

--- a/monoio/tests/fd_leak.rs
+++ b/monoio/tests/fd_leak.rs
@@ -22,7 +22,7 @@ use monoio::io::AsyncReadRentExt;
 #[monoio::test_all(timer_enabled = true)]
 async fn test_fd_leak_cancel_fail() {
     // step 1 and 2
-    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let mut incoming = listener.accept();
     let fut = unsafe { std::pin::Pin::new_unchecked(&mut incoming) };
@@ -84,7 +84,7 @@ async fn test_fd_leak_cancel_fail() {
 #[cfg(feature = "async-cancel")]
 #[monoio::test_all(timer_enabled = true)]
 async fn test_fd_leak_try_cancel() {
-    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let incoming = listener.accept();
     assert!(monoio::select! {

--- a/monoio/tests/fd_leak.rs
+++ b/monoio/tests/fd_leak.rs
@@ -22,7 +22,9 @@ use monoio::io::AsyncReadRentExt;
 #[monoio::test_all(timer_enabled = true)]
 async fn test_fd_leak_cancel_fail() {
     // step 1 and 2
-    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = monoio::net::TcpListener::async_bind("127.0.0.1:0")
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
     let mut incoming = listener.accept();
     let fut = unsafe { std::pin::Pin::new_unchecked(&mut incoming) };
@@ -84,7 +86,9 @@ async fn test_fd_leak_cancel_fail() {
 #[cfg(feature = "async-cancel")]
 #[monoio::test_all(timer_enabled = true)]
 async fn test_fd_leak_try_cancel() {
-    let listener = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = monoio::net::TcpListener::async_bind("127.0.0.1:0")
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
     let incoming = listener.accept();
     assert!(monoio::select! {

--- a/monoio/tests/tcp_accept.rs
+++ b/monoio/tests/tcp_accept.rs
@@ -7,7 +7,7 @@ macro_rules! test_accept {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind($target).unwrap();
+                let listener = TcpListener::bind($target).await.unwrap();
                 let addr = listener.local_addr().unwrap();
                 let (tx, rx) = local_sync::oneshot::channel();
                 monoio::spawn(async move {

--- a/monoio/tests/tcp_accept.rs
+++ b/monoio/tests/tcp_accept.rs
@@ -7,7 +7,7 @@ macro_rules! test_accept {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind($target).await.unwrap();
+                let listener = TcpListener::async_bind($target).await.unwrap();
                 let addr = listener.local_addr().unwrap();
                 let (tx, rx) = local_sync::oneshot::channel();
                 monoio::spawn(async move {
@@ -28,4 +28,19 @@ test_accept! {
     (socket_addr, "127.0.0.1:0".parse::<SocketAddr>().unwrap()),
     (str_port_tuple, ("127.0.0.1", 0)),
     (ip_port_tuple, ("127.0.0.1".parse::<IpAddr>().unwrap(), 0)),
+}
+
+#[monoio::test_all]
+async fn sync_bind_accept() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let addr = listener.local_addr().unwrap();
+    let (tx, rx) = local_sync::oneshot::channel();
+    monoio::spawn(async move {
+        let (socket, _) = listener.accept().await.unwrap();
+        assert!(tx.send(socket).is_ok());
+    });
+
+    let cli = TcpStream::connect(&addr).await.unwrap();
+    let srv = rx.await.unwrap();
+    assert_eq!(cli.local_addr().unwrap(), srv.peer_addr().unwrap());
 }

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -12,7 +12,7 @@ macro_rules! test_connect_ip {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind($target).unwrap();
+                let listener = TcpListener::bind($target).await.unwrap();
                 let addr = listener.local_addr().unwrap();
                 assert!($addr_f(&addr));
 
@@ -57,7 +57,7 @@ macro_rules! test_connect {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
                 let addr = $mapping(&listener);
 
                 let server = async {

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -1,7 +1,6 @@
 use std::{
     io::Write,
     net::{IpAddr, SocketAddr},
-    sync::LazyLock,
     thread::sleep,
     time::Duration,
 };
@@ -110,7 +109,7 @@ async fn connect_timeout_dst() {
         };
 
         let res = monoio::select! {
-            a = connect => false,
+            _ = connect => false,
             _ = monoio::time::sleep(std::time::Duration::from_secs(1)) => { true }
         };
         assert!(res);
@@ -128,14 +127,14 @@ fn create_test_server() -> u16 {
     let addr = listener.local_addr().unwrap();
 
     // the listener will not be closed until the test is done
-    let handler = std::thread::spawn(move || {
+    let _ = std::thread::spawn(move || {
         for stream in listener.incoming() {
             match stream {
                 Ok(mut stream) => {
                     sleep(Duration::from_millis(200));
                     let _ = stream.write_all(b"test server response");
                 }
-                Err(e) => eprintln!("connection failed: {}", e),
+                Err(e) => eprintln!("connection failed: {e}"),
             }
         }
     });
@@ -149,7 +148,7 @@ async fn cancel_read() {
 
     let server_port = create_test_server();
 
-    let mut s = TcpStream::connect(format!("127.0.0.1:{}", server_port))
+    let mut s = TcpStream::connect(format!("127.0.0.1:{server_port}"))
         .await
         .unwrap();
     let buf = vec![0; 20];
@@ -172,7 +171,7 @@ async fn cancel_select() {
 
     let server_port = create_test_server();
 
-    let mut s = TcpStream::connect(format!("127.0.0.1:{}", server_port))
+    let mut s = TcpStream::connect(format!("127.0.0.1:{server_port}"))
         .await
         .unwrap();
     let buf = vec![0; 20];

--- a/monoio/tests/tcp_connect.rs
+++ b/monoio/tests/tcp_connect.rs
@@ -12,7 +12,7 @@ macro_rules! test_connect_ip {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind($target).await.unwrap();
+                let listener = TcpListener::async_bind($target).await.unwrap();
                 let addr = listener.local_addr().unwrap();
                 assert!($addr_f(&addr));
 
@@ -57,7 +57,7 @@ macro_rules! test_connect {
         $(
             #[monoio::test_all]
             async fn $ident() {
-                let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+                let listener = TcpListener::async_bind("127.0.0.1:0").await.unwrap();
                 let addr = $mapping(&listener);
 
                 let server = async {

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -9,7 +9,7 @@ async fn echo_server() {
 
     let (tx, rx) = local_sync::oneshot::channel();
 
-    let srv = TcpListener::bind("127.0.0.1:0").unwrap();
+    let srv = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = srv.local_addr().unwrap();
 
     let msg = "foo bar baz";
@@ -68,7 +68,7 @@ async fn echo_server() {
 
 #[monoio::test_all(timer_enabled = true)]
 async fn rw_able() {
-    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let listener_addr = listener.local_addr().unwrap();
 
     monoio::select! {
@@ -106,7 +106,9 @@ async fn echo_tfo() {
 
     let bind_addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     let opts = monoio::net::ListenerOpts::default().tcp_fast_open(true);
-    let listener = TcpListener::bind_with_config(bind_addr, &opts).unwrap();
+    let listener = TcpListener::bind_with_config(bind_addr, &opts)
+        .await
+        .unwrap();
     let addr = listener.local_addr().unwrap();
     let (tx, rx) = local_sync::oneshot::channel();
     monoio::spawn(async move {

--- a/monoio/tests/tcp_echo.rs
+++ b/monoio/tests/tcp_echo.rs
@@ -9,7 +9,7 @@ async fn echo_server() {
 
     let (tx, rx) = local_sync::oneshot::channel();
 
-    let srv = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let srv = TcpListener::async_bind("127.0.0.1:0").await.unwrap();
     let addr = srv.local_addr().unwrap();
 
     let msg = "foo bar baz";
@@ -68,7 +68,7 @@ async fn echo_server() {
 
 #[monoio::test_all(timer_enabled = true)]
 async fn rw_able() {
-    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let listener = TcpListener::async_bind("127.0.0.1:0").await.unwrap();
     let listener_addr = listener.local_addr().unwrap();
 
     monoio::select! {
@@ -106,7 +106,7 @@ async fn echo_tfo() {
 
     let bind_addr = "127.0.0.1:0".parse::<SocketAddr>().unwrap();
     let opts = monoio::net::ListenerOpts::default().tcp_fast_open(true);
-    let listener = TcpListener::bind_with_config(bind_addr, &opts)
+    let listener = TcpListener::async_bind_with_config(bind_addr, &opts)
         .await
         .unwrap();
     let addr = listener.local_addr().unwrap();

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -13,7 +13,7 @@ use monoio::{
 async fn split() -> Result<()> {
     const MSG: &[u8] = b"split";
 
-    let listener = TcpListener::bind("127.0.0.1:0")?;
+    let listener = TcpListener::bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
     let (stream1, (mut stream2, _)) = try_join! {

--- a/monoio/tests/tcp_into_split.rs
+++ b/monoio/tests/tcp_into_split.rs
@@ -13,7 +13,7 @@ use monoio::{
 async fn split() -> Result<()> {
     const MSG: &[u8] = b"split";
 
-    let listener = TcpListener::bind("127.0.0.1:0").await?;
+    let listener = TcpListener::async_bind("127.0.0.1:0").await?;
     let addr = listener.local_addr()?;
 
     let (stream1, (mut stream2, _)) = try_join! {

--- a/monoio/tests/udp.rs
+++ b/monoio/tests/udp.rs
@@ -4,10 +4,10 @@ use monoio::net::udp::UdpSocket;
 async fn connect() {
     const MSG: &str = "foo bar baz";
 
-    let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.connect(passive_addr).await.unwrap();
@@ -32,19 +32,19 @@ async fn send_to() {
         };
     }
 
-    let passive1 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive1 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive1_addr = passive1.local_addr().unwrap();
 
     let passive01 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive01_addr = passive01.local_addr().unwrap();
 
-    let passive2 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive2 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive2_addr = passive2.local_addr().unwrap();
 
-    let passive3 = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive3 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive3_addr = passive3.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.send_to(MSG, passive01_addr).await.0.unwrap();
@@ -61,10 +61,10 @@ async fn send_to() {
 async fn rw_able() {
     const MSG: &str = "foo bar baz";
 
-    let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
 
     assert!(active.writable(false).await.is_ok());
     monoio::select! {
@@ -81,7 +81,7 @@ async fn rw_able() {
 
 #[monoio::test_all(timer_enabled = true)]
 async fn cancel_recv_from() {
-    let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
     let canceller = monoio::io::Canceller::new();
     let recv = passive.cancelable_recv_from(vec![0; 20], canceller.handle());
     let mut recv = std::pin::pin!(recv);

--- a/monoio/tests/udp.rs
+++ b/monoio/tests/udp.rs
@@ -4,10 +4,10 @@ use monoio::net::udp::UdpSocket;
 async fn connect() {
     const MSG: &str = "foo bar baz";
 
-    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.connect(passive_addr).await.unwrap();
@@ -18,6 +18,22 @@ async fn connect() {
     assert_eq!(MSG.as_bytes(), &buffer);
     assert_eq!(active.local_addr().unwrap(), active_addr);
     assert_eq!(active.peer_addr().unwrap(), passive_addr);
+}
+
+#[monoio::test_all]
+async fn sync_bind_connect() {
+    const MSG: &str = "sync bind udp";
+
+    let passive = UdpSocket::bind("127.0.0.1:0").unwrap();
+    let passive_addr = passive.local_addr().unwrap();
+
+    let active = UdpSocket::bind("127.0.0.1:0").unwrap();
+    active.connect(passive_addr).await.unwrap();
+    active.send(MSG).await.0.unwrap();
+
+    let (res, buffer) = passive.recv(Vec::with_capacity(32)).await;
+    res.unwrap();
+    assert_eq!(MSG.as_bytes(), &buffer);
 }
 
 #[monoio::test_all]
@@ -32,19 +48,19 @@ async fn send_to() {
         };
     }
 
-    let passive1 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive1 = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let passive1_addr = passive1.local_addr().unwrap();
 
     let passive01 = std::net::UdpSocket::bind("127.0.0.1:0").unwrap();
     let passive01_addr = passive01.local_addr().unwrap();
 
-    let passive2 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive2 = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let passive2_addr = passive2.local_addr().unwrap();
 
-    let passive3 = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive3 = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let passive3_addr = passive3.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let active_addr = active.local_addr().unwrap();
 
     active.send_to(MSG, passive01_addr).await.0.unwrap();
@@ -61,10 +77,10 @@ async fn send_to() {
 async fn rw_able() {
     const MSG: &str = "foo bar baz";
 
-    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let passive_addr = passive.local_addr().unwrap();
 
-    let active = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let active = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
 
     assert!(active.writable(false).await.is_ok());
     monoio::select! {
@@ -81,7 +97,7 @@ async fn rw_able() {
 
 #[monoio::test_all(timer_enabled = true)]
 async fn cancel_recv_from() {
-    let passive = UdpSocket::bind("127.0.0.1:0").await.unwrap();
+    let passive = UdpSocket::async_bind("127.0.0.1:0").await.unwrap();
     let canceller = monoio::io::Canceller::new();
     let recv = passive.cancelable_recv_from(vec![0; 20], canceller.handle());
     let mut recv = std::pin::pin!(recv);

--- a/monoio/tests/uds_stream.rs
+++ b/monoio/tests/uds_stream.rs
@@ -13,7 +13,7 @@ async fn accept_read_write() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("connect.sock");
 
-    let listener = UnixListener::bind(&sock_path)?;
+    let listener = UnixListener::bind(&sock_path).await?;
 
     let accept = listener.accept();
     let connect = UnixStream::connect(&sock_path);
@@ -50,7 +50,7 @@ async fn shutdown() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("connect.sock");
 
-    let listener = UnixListener::bind(&sock_path)?;
+    let listener = UnixListener::bind(&sock_path).await?;
 
     let accept = listener.accept();
     let connect = UnixStream::connect(&sock_path);

--- a/monoio/tests/uds_stream.rs
+++ b/monoio/tests/uds_stream.rs
@@ -13,7 +13,7 @@ async fn accept_read_write() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("connect.sock");
 
-    let listener = UnixListener::bind(&sock_path).await?;
+    let listener = UnixListener::async_bind(&sock_path).await?;
 
     let accept = listener.accept();
     let connect = UnixStream::connect(&sock_path);
@@ -50,7 +50,7 @@ async fn shutdown() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("connect.sock");
 
-    let listener = UnixListener::bind(&sock_path).await?;
+    let listener = UnixListener::async_bind(&sock_path).await?;
 
     let accept = listener.accept();
     let connect = UnixStream::connect(&sock_path);
@@ -61,5 +61,33 @@ async fn shutdown() -> std::io::Result<()> {
     // Read from the server should return 0 to indicate the channel has been closed.
     let n = server.read(Box::new([0u8; 1])).await.0?;
     assert_eq!(n, 0);
+    Ok(())
+}
+
+#[monoio::test_all]
+async fn sync_bind_accept_read_write() -> std::io::Result<()> {
+    let dir = tempfile::Builder::new()
+        .prefix("monoio-uds-tests")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("connect-sync.sock");
+
+    let listener = UnixListener::bind(&sock_path)?;
+
+    let accept = listener.accept();
+    let connect = UnixStream::connect(&sock_path);
+    let ((mut server, _), mut client) = try_join(accept, connect).await?;
+
+    let write_len = client.write_all(b"hello").await.0?;
+    assert_eq!(write_len, 5);
+    drop(client);
+
+    let buf = Box::new([0u8; 5]);
+    let (res, buf) = server.read_exact(buf).await;
+    assert_eq!(res.unwrap(), 5);
+    assert_eq!(&buf[..], b"hello");
+    let len = server.read(buf).await.0?;
+    assert_eq!(len, 0);
+
     Ok(())
 }

--- a/monoio/tests/unix_seqpacket.rs
+++ b/monoio/tests/unix_seqpacket.rs
@@ -9,7 +9,7 @@ async fn test_seqpacket() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("seqpacket.sock");
 
-    let listener = UnixSeqpacketListener::bind(&sock_path).unwrap();
+    let listener = UnixSeqpacketListener::bind(&sock_path).await.unwrap();
     monoio::spawn(async move {
         let (conn, _addr) = listener.accept().await.unwrap();
         let (res, buf) = conn.recv(vec![0; 100]).await;

--- a/monoio/tests/unix_seqpacket.rs
+++ b/monoio/tests/unix_seqpacket.rs
@@ -9,7 +9,30 @@ async fn test_seqpacket() -> std::io::Result<()> {
         .unwrap();
     let sock_path = dir.path().join("seqpacket.sock");
 
-    let listener = UnixSeqpacketListener::bind(&sock_path).await.unwrap();
+    let listener = UnixSeqpacketListener::async_bind(&sock_path).await.unwrap();
+    monoio::spawn(async move {
+        let (conn, _addr) = listener.accept().await.unwrap();
+        let (res, buf) = conn.recv(vec![0; 100]).await;
+        assert_eq!(res.unwrap(), 5);
+        assert_eq!(buf, b"hello");
+    });
+    let conn = UnixSeqpacket::connect(&sock_path).await.unwrap();
+    conn.send(b"hello").await.0.unwrap();
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+#[monoio::test_all]
+async fn test_seqpacket_sync_bind() -> std::io::Result<()> {
+    use monoio::net::unix::{UnixSeqpacket, UnixSeqpacketListener};
+
+    let dir = tempfile::Builder::new()
+        .prefix("monoio-unix-seqpacket-tests")
+        .tempdir()
+        .unwrap();
+    let sock_path = dir.path().join("seqpacket-sync.sock");
+
+    let listener = UnixSeqpacketListener::bind(&sock_path).unwrap();
     monoio::spawn(async move {
         let (conn, _addr) = listener.accept().await.unwrap();
         let (res, buf) = conn.recv(vec![0; 100]).await;

--- a/monoio/tests/zero_copy.rs
+++ b/monoio/tests/zero_copy.rs
@@ -8,7 +8,7 @@ async fn zero_copy_for_tcp() {
     };
 
     const MSG: &[u8] = b"copy for split";
-    let srv = monoio::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let srv = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let (mut c_tx, mut c_rx) = local_sync::oneshot::channel::<()>();
     let addr = srv.local_addr().unwrap();
     monoio::spawn(async move {
@@ -43,7 +43,7 @@ async fn zero_copy_for_uds() {
         .tempdir()
         .unwrap();
     let sock_path = dir.path().join("zero_copy.sock");
-    let srv = monoio::net::UnixListener::bind(&sock_path).unwrap();
+    let srv = monoio::net::UnixListener::bind(&sock_path).await.unwrap();
     let (mut c_tx, mut c_rx) = local_sync::oneshot::channel::<()>();
     monoio::spawn(async move {
         let stream = UnixStream::connect(&sock_path).await.unwrap();

--- a/monoio/tests/zero_copy.rs
+++ b/monoio/tests/zero_copy.rs
@@ -8,7 +8,9 @@ async fn zero_copy_for_tcp() {
     };
 
     const MSG: &[u8] = b"copy for split";
-    let srv = monoio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let srv = monoio::net::TcpListener::async_bind("127.0.0.1:0")
+        .await
+        .unwrap();
     let (mut c_tx, mut c_rx) = local_sync::oneshot::channel::<()>();
     let addr = srv.local_addr().unwrap();
     monoio::spawn(async move {
@@ -43,7 +45,9 @@ async fn zero_copy_for_uds() {
         .tempdir()
         .unwrap();
     let sock_path = dir.path().join("zero_copy.sock");
-    let srv = monoio::net::UnixListener::bind(&sock_path).await.unwrap();
+    let srv = monoio::net::UnixListener::async_bind(&sock_path)
+        .await
+        .unwrap();
     let (mut c_tx, mut c_rx) = local_sync::oneshot::channel::<()>();
     monoio::spawn(async move {
         let stream = UnixStream::connect(&sock_path).await.unwrap();


### PR DESCRIPTION
This PR is mainly to make `socket`, `bind`, `listen` using io uring.

To be noted, I choose to let `bind` and `listen` be features because using these needs your kernel version >= 6.11.

So, this PR finishes the following tasks:

- [x] add socket, bind, listen op
- [x] change all the related function to async function
- [x] replace the original sync syscall function to io uring op
- [x] disable ci on armv7 and s390x, because the crate `io-uring` doesn't provide the prebuild `sys.rs` for these arch. 
- [x] other small fix

complete #348