### PR TITLE
feat: implement AsReadFd and AsWriteFd for File

### DIFF
--- a/monoio/src/fs/file/mod.rs
+++ b/monoio/src/fs/file/mod.rs
@@ -4,7 +4,7 @@ use crate::{
     buf::{IoBuf, IoBufMut, IoVecBuf, IoVecBufMut},
     driver::{op::Op, shared_fd::SharedFd},
     fs::OpenOptions,
-    io::{AsyncReadRent, AsyncWriteRent},
+    io::{as_fd::{AsReadFd, AsWriteFd, SharedFdWrapper}, AsyncReadRent, AsyncWriteRent},
     BufResult,
 };
 
@@ -775,5 +775,19 @@ impl AsyncReadRentAt for File {
         pos: usize,
     ) -> impl Future<Output = BufResult<usize, T>> {
         File::read_at(self, buf, pos as u64)
+    }
+}
+
+impl AsReadFd for File {
+    #[inline]
+    fn as_reader_fd(&mut self) -> &SharedFdWrapper {
+        SharedFdWrapper::new(&self.fd)
+    }
+}
+
+impl AsWriteFd for File {
+    #[inline]
+    fn as_writer_fd(&mut self) -> &SharedFdWrapper {
+        SharedFdWrapper::new(&self.fd)
     }
 }

--- a/monoio/tests/zero_copy.rs
+++ b/monoio/tests/zero_copy.rs
@@ -30,6 +30,29 @@ async fn zero_copy_for_tcp() {
 
 #[cfg(all(target_os = "linux", feature = "splice"))]
 #[monoio::test_all]
+async fn splice_file_to_pipe() {
+    use monoio::{fs::File, io::splice::SpliceSource, net::unix::new_pipe};
+
+    let dir = tempfile::Builder::new()
+        .prefix("monoio-splice-tests")
+        .tempdir()
+        .unwrap();
+    let file_path = dir.path().join("splice_test.txt");
+    let content = b"Hello, splice!";
+    std::fs::write(&file_path, content).unwrap();
+
+    let mut file = File::open(&file_path).await.unwrap();
+    let (_r, mut w) = new_pipe().unwrap();
+
+    let n = file
+        .splice_to_pipe(&mut w, content.len() as u32)
+        .await
+        .unwrap();
+    assert_eq!(n as usize, content.len());
+}
+
+#[cfg(all(target_os = "linux", feature = "splice"))]
+#[monoio::test_all]
 async fn zero_copy_for_uds() {
     use monoio::{
         buf::IoBufMut,


### PR DESCRIPTION
  ## Problem

  `monoio::fs::File` can't be used with splice traits (`SpliceSource`, `SpliceSink`) because it
  doesn't implement `AsReadFd` or `AsWriteFd`.

  ## Approach

  Implement `AsReadFd` and `AsWriteFd` for `File`, matching the pattern used by `TcpStream`, `UnixStream`, and `Pipe`.

  The implementation delegates to the file's internal `SharedFd`:

  - `as_reader_fd()` -> wraps `self.fd` in `SharedFdWrapper`
  - `as_writer_fd()` -> wraps `self.fd` in `SharedFdWrapper`

  This enables `file.splice_to_pipe()` and `file.splice_from_pipe()` calls.