### PR TITLE
Fix docs: update hyper client example description

### DIFF
--- a/docs/en/http.md
+++ b/docs/en/http.md
@@ -77,18 +77,27 @@ async fn hyper_handler(req: Request<Body>) -> Result<Response<Body>, std::conver
 
 The client's implementation involves how to create a connection. This is also strongly coupled by Runtime, so hyper provides the `Connector` abstraction, which is defined as a Tower Service, which receives `hyper::Uri` and returns the implementation `tokio::io::AsyncRead + The future of tokio::io::AsyncWrite + hyper::client::connect::Connection` (that is, connection in a broad sense).
 
-We implement `HyperConnection` based on `monoio_compat::TcpStreamCompat`; and provide `HyperConnector` to implement this `Service` (for specific implementation refer to [`examples/hyper_client.rs`](/examples/hyper_client.rs)).
+We implement monoio's IO object compatibility with hyper using `monoio_compat::hyper::MonoioIo`. For specific implementation refer to [`examples/hyper_client.rs`](/examples/hyper_client.rs).
 
-Finally, we specify `Executor` and `Connector` to create a client and do a request.
+Use `hyper::client::conn::http1::handshake` to create HTTP connection directly and make a request.
 
 ```rust
-let client = hyper::Client::builder()
-    .executor(HyperExecutor)
-    .build::<HyperConnector, hyper::Body>(connector);
-let res = client
-    .get("http://127.0.0.1:23300/monoio".parse().unwrap())
-    .await
-    .expect("failed to fetch");
+let stream = TcpStream::connect(addr).await?.into_poll_io()?;
+let io = MonoioIo::new(stream);
+
+let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+monoio::spawn(async move {
+    if let Err(err) = conn.await {
+        println!("Connection failed: {:?}", err);
+    }
+});
+
+let req = Request::builder()
+    .uri(path)
+    .header(hyper::header::HOST, authority.as_str())
+    .body(Empty::<Bytes>::new())?;
+
+let mut res = sender.send_request(req).await?;
 ```
 
 An additional note here is that hyper does not support thread-per-core Runtime well. You can refer to the [issue](https://github.com/hyperium/hyper/issues/2341) mentioned by the author of Glommio.

--- a/docs/zh/http.md
+++ b/docs/zh/http.md
@@ -77,18 +77,27 @@ async fn hyper_handler(req: Request<Body>) -> Result<Response<Body>, std::conver
 
 客户端的实现涉及如何创建连接，这个也是 Runtime 强耦合的，所以 hyper 提供了 `Connector` 抽象，它被定义为一个 Tower Service，接收 `hyper::Uri` 返回实现 `tokio::io::AsyncRead + tokio::io::AsyncWrite + hyper::client::connect::Connection`（也就是广义上的连接）的 future。
 
-我们基于 `monoio_compat::TcpStreamCompat` 定义 `HyperConnection` 来实现上述约束；并提供 `HyperConnector` 实现这个 Service（具体实现参考 [`examples/hyper_client.rs`](/examples/hyper_client.rs)）。
+我们基于 `monoio_compat::hyper::MonoioIo` 来实现 monoio 的 IO 对象与 hyper 的兼容。具体实现参考 [`examples/hyper_client.rs`](/examples/hyper_client.rs)）。
 
-最后我们指定 Executor 和 Connector 创建 client，并发起请求。
+使用 `hyper::client::conn::http1::handshake` 直接创建 HTTP 连接并发起请求。
 
 ```rust
-let client = hyper::Client::builder()
-    .executor(HyperExecutor)
-    .build::<HyperConnector, hyper::Body>(connector);
-let res = client
-    .get("http://127.0.0.1:23300/monoio".parse().unwrap())
-    .await
-    .expect("failed to fetch");
+let stream = TcpStream::connect(addr).await?.into_poll_io()?;
+let io = MonoioIo::new(stream);
+
+let (mut sender, conn) = hyper::client::conn::http1::handshake(io).await?;
+monoio::spawn(async move {
+    if let Err(err) = conn.await {
+        println!("Connection failed: {:?}", err);
+    }
+});
+
+let req = Request::builder()
+    .uri(path)
+    .header(hyper::header::HOST, authority.as_str())
+    .body(Empty::<Bytes>::new())?;
+
+let mut res = sender.send_request(req).await?;
 ```
 
 这里要额外说明的是，hyper 并没有很好地支持 thread-per-core 的 Runtime。可以参考 Glommio 的作者提的 [issue](https://github.com/hyperium/hyper/issues/2341)。


### PR DESCRIPTION
Fixes #332. Updates documentation to reflect the current hyper client implementation using MonoioIo and handshake instead of the outdated HyperConnector approach.