### PR TITLE
feat: add IORING_OP_SEND_ZC zero-copy send support

### DIFF
--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -355,7 +355,7 @@ impl<T: IoBuf> Op<SendZc<T>> {
 impl<T: IoBuf> OpAble for SendZc<T> {
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
         #[allow(deprecated)]
-        const FLAGS: i32 = libc::MSG_NOSIGNAL as i32;
+        const FLAGS: i32 = libc::MSG_NOSIGNAL;
 
         opcode::SendZc::new(
             types::Fd(self.fd.raw_fd()),

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -355,14 +355,14 @@ impl<T: IoBuf> Op<SendZc<T>> {
 impl<T: IoBuf> OpAble for SendZc<T> {
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
         #[allow(deprecated)]
-        let flags = libc::MSG_NOSIGNAL as libc::c_int;
+        const FLAGS: u32 = libc::MSG_NOSIGNAL as u32;
 
         opcode::SendZc::new(
             types::Fd(self.fd.raw_fd()),
             self.buf.read_ptr(),
             self.buf.bytes_init() as _,
         )
-        .flags(flags)
+        .flags(FLAGS)
         .build()
     }
 

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -355,7 +355,7 @@ impl<T: IoBuf> Op<SendZc<T>> {
 impl<T: IoBuf> OpAble for SendZc<T> {
     fn uring_op(&mut self) -> io_uring::squeue::Entry {
         #[allow(deprecated)]
-        const FLAGS: u32 = libc::MSG_NOSIGNAL as u32;
+        const FLAGS: i32 = libc::MSG_NOSIGNAL as i32;
 
         opcode::SendZc::new(
             types::Fd(self.fd.raw_fd()),

--- a/monoio/src/driver/op/send.rs
+++ b/monoio/src/driver/op/send.rs
@@ -320,3 +320,153 @@ impl<T: IoBuf> OpAble for SendMsgUnix<T> {
         crate::syscall!(sendmsg@NON_FD(fd, &mut self.info.2 as *mut _, FLAGS))
     }
 }
+
+/// Zero-copy send using IORING_OP_SEND_ZC (Linux 6.0+).
+///
+/// This operation produces two CQEs: the first indicates send completion,
+/// and the second (notification) signals that the kernel has released the buffer.
+/// The future only resolves after both CQEs arrive, ensuring buffer safety.
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub(crate) struct SendZc<T> {
+    /// Holds a strong ref to the FD, preventing the file from being closed
+    /// while the operation is in-flight.
+    #[allow(unused)]
+    fd: SharedFd,
+
+    pub(crate) buf: T,
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+impl<T: IoBuf> Op<SendZc<T>> {
+    pub(crate) fn send_zc(fd: SharedFd, buf: T) -> io::Result<Self> {
+        Op::submit_with(SendZc { fd, buf })
+    }
+
+    pub(crate) async fn result(self) -> BufResult<usize, T> {
+        let complete = self.await;
+        (
+            complete.meta.result.map(|v| v.into_inner() as _),
+            complete.data.buf,
+        )
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+impl<T: IoBuf> OpAble for SendZc<T> {
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        #[allow(deprecated)]
+        let flags = libc::MSG_NOSIGNAL as libc::c_int;
+
+        opcode::SendZc::new(
+            types::Fd(self.fd.raw_fd()),
+            self.buf.read_ptr(),
+            self.buf.bytes_init() as _,
+        )
+        .flags(flags)
+        .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[inline]
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
+        self.fd
+            .registered_index()
+            .map(|idx| (Direction::Write, idx))
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        // Fallback to normal send on legacy driver
+        let fd = self.fd.as_raw_fd();
+        #[allow(deprecated)]
+        let flags = libc::MSG_NOSIGNAL as _;
+
+        crate::syscall!(send@NON_FD(
+            fd,
+            self.buf.read_ptr() as _,
+            self.buf.bytes_init(),
+            flags
+        ))
+    }
+}
+
+/// Zero-copy sendmsg using IORING_OP_SENDMSG_ZC (Linux 6.1+).
+///
+/// Like `SendZc`, this produces two CQEs and the future only resolves
+/// after the notification CQE arrives.
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+pub(crate) struct SendMsgZc<T> {
+    /// Holds a strong ref to the FD, preventing the file from being closed
+    /// while the operation is in-flight.
+    #[allow(unused)]
+    fd: SharedFd,
+
+    /// Reference to the in-flight buffer.
+    pub(crate) buf: T,
+    pub(crate) info: Box<(Option<SockAddr>, IoVecMeta, MsgMeta)>,
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+impl<T: IoBuf> Op<SendMsgZc<T>> {
+    pub(crate) fn send_msg_zc(
+        fd: SharedFd,
+        buf: T,
+        socket_addr: Option<SocketAddr>,
+    ) -> io::Result<Self> {
+        let mut info: Box<(Option<SockAddr>, IoVecMeta, MsgMeta)> = Box::new((
+            socket_addr.map(Into::into),
+            IoVecMeta::from(&buf),
+            unsafe { std::mem::zeroed() },
+        ));
+
+        info.2.msg_iov = info.1.write_iovec_ptr();
+        info.2.msg_iovlen = info.1.write_iovec_len() as _;
+        match info.0.as_ref() {
+            Some(socket_addr) => {
+                info.2.msg_name = socket_addr.as_ptr() as *mut libc::c_void;
+                info.2.msg_namelen = socket_addr.len();
+            }
+            None => {
+                info.2.msg_name = std::ptr::null_mut();
+                info.2.msg_namelen = 0;
+            }
+        }
+
+        Op::submit_with(SendMsgZc { fd, buf, info })
+    }
+
+    pub(crate) async fn wait(self) -> BufResult<usize, T> {
+        let complete = self.await;
+        let res = complete.meta.result.map(|v| v.into_inner() as _);
+        let buf = complete.data.buf;
+        (res, buf)
+    }
+}
+
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+impl<T: IoBuf> OpAble for SendMsgZc<T> {
+    fn uring_op(&mut self) -> io_uring::squeue::Entry {
+        #[allow(deprecated)]
+        const FLAGS: u32 = libc::MSG_NOSIGNAL as u32;
+        opcode::SendMsgZc::new(types::Fd(self.fd.raw_fd()), &*self.info.2)
+            .flags(FLAGS)
+            .build()
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    #[inline]
+    fn legacy_interest(&self) -> Option<(Direction, usize)> {
+        self.fd
+            .registered_index()
+            .map(|idx| (Direction::Write, idx))
+    }
+
+    #[cfg(any(feature = "legacy", feature = "poll-io"))]
+    fn legacy_call(&mut self) -> io::Result<MaybeFd> {
+        // Fallback to normal sendmsg on legacy driver
+        #[allow(deprecated)]
+        const FLAGS: libc::c_int = libc::MSG_NOSIGNAL as libc::c_int;
+        let fd = self.fd.as_raw_fd();
+        crate::syscall!(sendmsg@NON_FD(fd, &*self.info.2, FLAGS))
+    }
+}

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -524,10 +524,10 @@ impl Drop for Inner {
         #[allow(unreachable_patterns)]
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
-            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..)) => {
-                if super::op::Op::close(fd).is_err() {
-                    let _ = unsafe { std::fs::File::from_raw_fd(fd) };
-                };
+            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..))
+                if super::op::Op::close(fd).is_err() =>
+            {
+                let _ = unsafe { std::fs::File::from_raw_fd(fd) };
             }
             #[cfg(feature = "legacy")]
             State::Legacy(idx) => drop_legacy(fd, *idx),

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -524,10 +524,10 @@ impl Drop for Inner {
         #[allow(unreachable_patterns)]
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
-            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..))
-                if super::op::Op::close(fd).is_err() =>
-            {
-                let _ = unsafe { std::fs::File::from_raw_fd(fd) };
+            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..)) => {
+                if super::op::Op::close(fd).is_err() {
+                    let _ = unsafe { std::fs::File::from_raw_fd(fd) };
+                }
             }
             #[cfg(feature = "legacy")]
             State::Legacy(idx) => drop_legacy(fd, *idx),

--- a/monoio/src/driver/shared_fd.rs
+++ b/monoio/src/driver/shared_fd.rs
@@ -524,10 +524,10 @@ impl Drop for Inner {
         #[allow(unreachable_patterns)]
         match state {
             #[cfg(all(target_os = "linux", feature = "iouring"))]
-            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..)) => {
-                if super::op::Op::close(fd).is_err() {
-                    let _ = unsafe { std::fs::File::from_raw_fd(fd) };
-                }
+            State::Uring(UringState::Init) | State::Uring(UringState::Waiting(..))
+                if super::op::Op::close(fd).is_err() =>
+            {
+                let _ = unsafe { std::fs::File::from_raw_fd(fd) };
             }
             #[cfg(feature = "legacy")]
             State::Legacy(idx) => drop_legacy(fd, *idx),

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -63,6 +63,7 @@ impl Ref<'_, MaybeFdLifecycle> {
     // # Safety
     // Caller must make sure the result is valid since it may contain fd or a length hint.
     pub(crate) unsafe fn complete(mut self, result: io::Result<u32>, flags: u32) {
+        let is_fd = self.is_fd;
         let ref_mut = &mut self.lifecycle;
 
         // Handle notification CQE (second CQE of a multi-CQE op like SEND_ZC)
@@ -98,7 +99,7 @@ impl Ref<'_, MaybeFdLifecycle> {
 
         // Handle first CQE with MORE flag (more CQEs will follow, e.g. SEND_ZC)
         if flags & IORING_CQE_F_MORE != 0 {
-            let result = MaybeFd::new_result(result, self.is_fd);
+            let result = MaybeFd::new_result(result, is_fd);
             match ref_mut {
                 Lifecycle::Submitted => {
                     *ref_mut = Lifecycle::CompletedMore(result, flags);
@@ -128,7 +129,7 @@ impl Ref<'_, MaybeFdLifecycle> {
         }
 
         // Normal single-CQE completion (existing behavior)
-        let result = MaybeFd::new_result(result, self.is_fd);
+        let result = MaybeFd::new_result(result, is_fd);
         match ref_mut {
             Lifecycle::Submitted => {
                 *ref_mut = Lifecycle::Completed(result, flags);

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -74,25 +74,31 @@ impl Ref<'_, MaybeFdLifecycle> {
                     let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
                     match old {
                         Lifecycle::CompletedMore(stored_result, stored_flags) => {
-                            *ref_mut = Lifecycle::Completed(stored_result, stored_flags);
+                            *ref_mut = Lifecycle::Completed(
+                                stored_result,
+                                stored_flags & !IORING_CQE_F_MORE,
+                            );
                         }
-                        _ => std::hint::unreachable_unchecked(),
+                        _ => unreachable!("lifecycle state mismatch"),
                     }
                 }
                 Lifecycle::WaitingMore(_, _, _) => {
                     let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
                     match old {
                         Lifecycle::WaitingMore(waker, stored_result, stored_flags) => {
-                            *ref_mut = Lifecycle::Completed(stored_result, stored_flags);
+                            *ref_mut = Lifecycle::Completed(
+                                stored_result,
+                                stored_flags & !IORING_CQE_F_MORE,
+                            );
                             waker.wake();
                         }
-                        _ => std::hint::unreachable_unchecked(),
+                        _ => unreachable!("lifecycle state mismatch"),
                     }
                 }
                 Lifecycle::IgnoredMore(..) => {
                     self.remove();
                 }
-                _ => std::hint::unreachable_unchecked(),
+                _ => unreachable!("lifecycle state mismatch"),
             }
             return;
         }
@@ -111,7 +117,7 @@ impl Ref<'_, MaybeFdLifecycle> {
                             // Don't wake yet — we need to wait for the notification CQE
                             *ref_mut = Lifecycle::WaitingMore(waker, result, flags);
                         }
-                        _ => std::hint::unreachable_unchecked(),
+                        _ => unreachable!("lifecycle state mismatch"),
                     }
                 }
                 Lifecycle::Ignored(_) => {
@@ -120,10 +126,10 @@ impl Ref<'_, MaybeFdLifecycle> {
                         Lifecycle::Ignored(data) => {
                             *ref_mut = Lifecycle::IgnoredMore(data);
                         }
-                        _ => std::hint::unreachable_unchecked(),
+                        _ => unreachable!("lifecycle state mismatch"),
                     }
                 }
-                _ => std::hint::unreachable_unchecked(),
+                _ => unreachable!("lifecycle state mismatch"),
             }
             return;
         }
@@ -140,14 +146,14 @@ impl Ref<'_, MaybeFdLifecycle> {
                     Lifecycle::Waiting(waker) => {
                         waker.wake();
                     }
-                    _ => std::hint::unreachable_unchecked(),
+                    _ => unreachable!("lifecycle state mismatch"),
                 }
             }
             Lifecycle::Ignored(..) => {
                 self.remove();
             }
-            Lifecycle::Completed(..) => std::hint::unreachable_unchecked(),
-            _ => std::hint::unreachable_unchecked(),
+            Lifecycle::Completed(..) => unreachable!("lifecycle state mismatch"),
+            _ => unreachable!("lifecycle state mismatch"),
         }
     }
 
@@ -172,7 +178,7 @@ impl Ref<'_, MaybeFdLifecycle> {
                     Lifecycle::CompletedMore(result, flags) => {
                         *ref_mut = Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
                     }
-                    _ => unsafe { std::hint::unreachable_unchecked() },
+                    _ => unreachable!("lifecycle state mismatch"),
                 }
                 return Poll::Pending;
             }
@@ -183,7 +189,7 @@ impl Ref<'_, MaybeFdLifecycle> {
                         Lifecycle::WaitingMore(_, result, flags) => {
                             *ref_mut = Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
                         }
-                        _ => unsafe { std::hint::unreachable_unchecked() },
+                        _ => unreachable!("lifecycle state mismatch"),
                     }
                 }
                 return Poll::Pending;
@@ -193,7 +199,7 @@ impl Ref<'_, MaybeFdLifecycle> {
 
         match self.remove().lifecycle {
             Lifecycle::Completed(result, flags) => Poll::Ready(CompletionMeta { result, flags }),
-            _ => unsafe { std::hint::unreachable_unchecked() },
+            _ => unreachable!("lifecycle state mismatch"),
         }
     }
 
@@ -222,17 +228,245 @@ impl Ref<'_, MaybeFdLifecycle> {
                     Lifecycle::CompletedMore(_, _) | Lifecycle::WaitingMore(_, _, _) => {
                         *ref_mut = Lifecycle::IgnoredMore(boxed_data);
                     }
-                    _ => unsafe { std::hint::unreachable_unchecked() },
+                    _ => unreachable!("lifecycle state mismatch"),
                 }
                 return false;
             }
             Lifecycle::Completed(..) => {
                 self.remove();
             }
-            Lifecycle::Ignored(..) | Lifecycle::IgnoredMore(..) => unsafe {
-                std::hint::unreachable_unchecked()
+            Lifecycle::Ignored(..) | Lifecycle::IgnoredMore(..) => {
+                unreachable!("lifecycle state mismatch")
             },
         }
         true
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{
+            atomic::{AtomicBool, Ordering},
+            Arc,
+        },
+        task::{Context, Poll, RawWaker, RawWakerVTable, Waker},
+    };
+
+    use super::*;
+    use crate::utils::slab::Slab;
+
+    fn vtable_ref() -> &'static RawWakerVTable {
+        &RawWakerVTable::new(
+            |ptr| {
+                let arc = unsafe { Arc::from_raw(ptr as *const AtomicBool) };
+                let cloned = arc.clone();
+                std::mem::forget(arc);
+                RawWaker::new(Arc::into_raw(cloned) as *const (), vtable_ref())
+            },
+            |ptr| {
+                let arc = unsafe { Arc::from_raw(ptr as *const AtomicBool) };
+                arc.store(true, Ordering::SeqCst);
+            },
+            |ptr| {
+                let arc = unsafe { Arc::from_raw(ptr as *const AtomicBool) };
+                arc.store(true, Ordering::SeqCst);
+                std::mem::forget(arc);
+            },
+            |ptr| {
+                unsafe { Arc::from_raw(ptr as *const AtomicBool) };
+            },
+        )
+    }
+
+    /// Create a waker that sets a flag when woken.
+    fn flag_waker() -> (Waker, Arc<AtomicBool>) {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_clone = flag.clone();
+        let raw = RawWaker::new(Arc::into_raw(flag_clone) as *const (), vtable_ref());
+        let waker = unsafe { Waker::from_raw(raw) };
+        (waker, flag)
+    }
+
+    fn insert_lifecycle(slab: &mut Slab<MaybeFdLifecycle>) -> usize {
+        slab.insert(MaybeFdLifecycle::new(false))
+    }
+
+    /// Submitted → MORE CQE → CompletedMore → NOTIF CQE → Completed → poll → Ready
+    #[test]
+    fn multi_cqe_no_poll_between() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        // First CQE with MORE flag
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(42), IORING_CQE_F_MORE) };
+
+        // Notification CQE
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(0), IORING_CQE_F_NOTIF) };
+
+        // Poll should return Ready with the result from the first CQE
+        let (waker, _flag) = flag_waker();
+        let mut cx = Context::from_waker(&waker);
+        let r = slab.get(key).unwrap();
+        match r.poll_op(&mut cx) {
+            Poll::Ready(meta) => {
+                assert_eq!(meta.result.unwrap().into_inner(), 42);
+                // MORE flag should be cleared
+                assert_eq!(meta.flags & IORING_CQE_F_MORE, 0);
+            }
+            Poll::Pending => panic!("expected Ready"),
+        }
+    }
+
+    /// Submitted → poll → Waiting → MORE CQE → WaitingMore → poll (Pending)
+    /// → NOTIF CQE (wakes) → poll → Ready
+    #[test]
+    fn multi_cqe_poll_between() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        let (waker, woken) = flag_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // First poll: Submitted → Waiting
+        let r = slab.get(key).unwrap();
+        assert!(r.poll_op(&mut cx).is_pending());
+
+        // First CQE with MORE: Waiting → WaitingMore (should NOT wake)
+        woken.store(false, Ordering::SeqCst);
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(100), IORING_CQE_F_MORE) };
+        assert!(!woken.load(Ordering::SeqCst), "should not wake on MORE CQE");
+
+        // Poll again: WaitingMore → still Pending
+        let r = slab.get(key).unwrap();
+        assert!(r.poll_op(&mut cx).is_pending());
+
+        // Notification CQE: WaitingMore → Completed, wakes
+        woken.store(false, Ordering::SeqCst);
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(0), IORING_CQE_F_NOTIF) };
+        assert!(woken.load(Ordering::SeqCst), "should wake on NOTIF CQE");
+
+        // Final poll: Completed → Ready
+        let r = slab.get(key).unwrap();
+        match r.poll_op(&mut cx) {
+            Poll::Ready(meta) => {
+                assert_eq!(meta.result.unwrap().into_inner(), 100);
+                assert_eq!(meta.flags & IORING_CQE_F_MORE, 0);
+            }
+            Poll::Pending => panic!("expected Ready"),
+        }
+    }
+
+    /// Submitted → MORE CQE → CompletedMore → drop_op → IgnoredMore
+    /// → NOTIF CQE → slot removed
+    #[test]
+    fn multi_cqe_drop_before_notification_from_completed_more() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        // First CQE with MORE
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(10), IORING_CQE_F_MORE) };
+
+        // Drop the op (future dropped before notification)
+        let r = slab.get(key).unwrap();
+        let mut data: Option<()> = Some(());
+        let finished = r.drop_op(&mut data);
+        assert!(!finished, "op not finished yet, notification pending");
+
+        // Notification CQE arrives — should clean up the slot
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(0), IORING_CQE_F_NOTIF) };
+
+        // Slot should have been removed
+        assert!(slab.get(key).is_none());
+    }
+
+    /// Submitted → poll → Waiting → MORE CQE → WaitingMore → drop_op → IgnoredMore
+    /// → NOTIF CQE → slot removed
+    #[test]
+    fn multi_cqe_drop_before_notification_from_waiting_more() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        let (waker, _flag) = flag_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // Poll: Submitted → Waiting
+        let r = slab.get(key).unwrap();
+        assert!(r.poll_op(&mut cx).is_pending());
+
+        // First CQE with MORE: Waiting → WaitingMore
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(20), IORING_CQE_F_MORE) };
+
+        // Drop the op
+        let r = slab.get(key).unwrap();
+        let mut data: Option<()> = Some(());
+        let finished = r.drop_op(&mut data);
+        assert!(!finished, "op not finished yet, notification pending");
+
+        // Notification CQE arrives — should clean up the slot
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(0), IORING_CQE_F_NOTIF) };
+
+        // Slot should have been removed
+        assert!(slab.get(key).is_none());
+    }
+
+    /// Normal single-CQE completion path (regression guard).
+    #[test]
+    fn single_cqe_submitted_to_completed() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        // Complete without MORE flag
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(7), 0) };
+
+        // Poll should return Ready
+        let (waker, _flag) = flag_waker();
+        let mut cx = Context::from_waker(&waker);
+        let r = slab.get(key).unwrap();
+        match r.poll_op(&mut cx) {
+            Poll::Ready(meta) => {
+                assert_eq!(meta.result.unwrap().into_inner(), 7);
+                assert_eq!(meta.flags, 0);
+            }
+            Poll::Pending => panic!("expected Ready"),
+        }
+    }
+
+    /// Single-CQE with waker: Submitted → poll → Waiting → complete → wakes → poll → Ready
+    #[test]
+    fn single_cqe_with_waker() {
+        let mut slab = Slab::new();
+        let key = insert_lifecycle(&mut slab);
+
+        let (waker, woken) = flag_waker();
+        let mut cx = Context::from_waker(&waker);
+
+        // Poll: Submitted → Waiting
+        let r = slab.get(key).unwrap();
+        assert!(r.poll_op(&mut cx).is_pending());
+
+        // Complete: Waiting → Completed, wakes
+        woken.store(false, Ordering::SeqCst);
+        let r = slab.get(key).unwrap();
+        unsafe { r.complete(Ok(99), 0) };
+        assert!(woken.load(Ordering::SeqCst));
+
+        // Poll: Completed → Ready
+        let r = slab.get(key).unwrap();
+        match r.poll_op(&mut cx) {
+            Poll::Ready(meta) => {
+                assert_eq!(meta.result.unwrap().into_inner(), 99);
+            }
+            Poll::Pending => panic!("expected Ready"),
+        }
     }
 }

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -237,7 +237,7 @@ impl Ref<'_, MaybeFdLifecycle> {
             }
             Lifecycle::Ignored(..) | Lifecycle::IgnoredMore(..) => {
                 unreachable!("lifecycle state mismatch")
-            },
+            }
         }
         true
     }

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -180,8 +180,7 @@ impl Ref<'_, MaybeFdLifecycle> {
                     let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
                     match old {
                         Lifecycle::WaitingMore(_, result, flags) => {
-                            *ref_mut =
-                                Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
+                            *ref_mut = Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
                         }
                         _ => unsafe { std::hint::unreachable_unchecked() },
                     }

--- a/monoio/src/driver/uring/lifecycle.rs
+++ b/monoio/src/driver/uring/lifecycle.rs
@@ -11,6 +11,11 @@ use crate::{
     utils::slab::Ref,
 };
 
+/// Flag indicating more CQEs will follow for this SQE (e.g. SEND_ZC).
+const IORING_CQE_F_MORE: u32 = 2;
+/// Flag indicating this CQE is a zero-copy notification.
+const IORING_CQE_F_NOTIF: u32 = 8;
+
 enum Lifecycle {
     /// The operation has been submitted to uring and is currently in-flight
     Submitted,
@@ -25,6 +30,18 @@ enum Lifecycle {
 
     /// The operation has completed.
     Completed(io::Result<MaybeFd>, u32),
+
+    /// First CQE with IORING_CQE_F_MORE received, waiting for notification CQE.
+    /// The future has not been polled yet (was in Submitted state).
+    CompletedMore(io::Result<MaybeFd>, u32),
+
+    /// First CQE with IORING_CQE_F_MORE received, waiting for notification CQE.
+    /// The future is actively polling (was in Waiting state).
+    WaitingMore(Waker, io::Result<MaybeFd>, u32),
+
+    /// The future was dropped but a notification CQE is still pending.
+    #[allow(dead_code)]
+    IgnoredMore(Box<dyn std::any::Any>),
 }
 
 pub(crate) struct MaybeFdLifecycle {
@@ -46,8 +63,72 @@ impl Ref<'_, MaybeFdLifecycle> {
     // # Safety
     // Caller must make sure the result is valid since it may contain fd or a length hint.
     pub(crate) unsafe fn complete(mut self, result: io::Result<u32>, flags: u32) {
-        let result = MaybeFd::new_result(result, self.is_fd);
         let ref_mut = &mut self.lifecycle;
+
+        // Handle notification CQE (second CQE of a multi-CQE op like SEND_ZC)
+        if flags & IORING_CQE_F_NOTIF != 0 {
+            match ref_mut {
+                Lifecycle::CompletedMore(_, _) => {
+                    // Move stored result into Completed state
+                    let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                    match old {
+                        Lifecycle::CompletedMore(stored_result, stored_flags) => {
+                            *ref_mut = Lifecycle::Completed(stored_result, stored_flags);
+                        }
+                        _ => std::hint::unreachable_unchecked(),
+                    }
+                }
+                Lifecycle::WaitingMore(_, _, _) => {
+                    let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                    match old {
+                        Lifecycle::WaitingMore(waker, stored_result, stored_flags) => {
+                            *ref_mut = Lifecycle::Completed(stored_result, stored_flags);
+                            waker.wake();
+                        }
+                        _ => std::hint::unreachable_unchecked(),
+                    }
+                }
+                Lifecycle::IgnoredMore(..) => {
+                    self.remove();
+                }
+                _ => std::hint::unreachable_unchecked(),
+            }
+            return;
+        }
+
+        // Handle first CQE with MORE flag (more CQEs will follow, e.g. SEND_ZC)
+        if flags & IORING_CQE_F_MORE != 0 {
+            let result = MaybeFd::new_result(result, self.is_fd);
+            match ref_mut {
+                Lifecycle::Submitted => {
+                    *ref_mut = Lifecycle::CompletedMore(result, flags);
+                }
+                Lifecycle::Waiting(_) => {
+                    let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                    match old {
+                        Lifecycle::Waiting(waker) => {
+                            // Don't wake yet — we need to wait for the notification CQE
+                            *ref_mut = Lifecycle::WaitingMore(waker, result, flags);
+                        }
+                        _ => std::hint::unreachable_unchecked(),
+                    }
+                }
+                Lifecycle::Ignored(_) => {
+                    let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                    match old {
+                        Lifecycle::Ignored(data) => {
+                            *ref_mut = Lifecycle::IgnoredMore(data);
+                        }
+                        _ => std::hint::unreachable_unchecked(),
+                    }
+                }
+                _ => std::hint::unreachable_unchecked(),
+            }
+            return;
+        }
+
+        // Normal single-CQE completion (existing behavior)
+        let result = MaybeFd::new_result(result, self.is_fd);
         match ref_mut {
             Lifecycle::Submitted => {
                 *ref_mut = Lifecycle::Completed(result, flags);
@@ -65,6 +146,7 @@ impl Ref<'_, MaybeFdLifecycle> {
                 self.remove();
             }
             Lifecycle::Completed(..) => std::hint::unreachable_unchecked(),
+            _ => std::hint::unreachable_unchecked(),
         }
     }
 
@@ -79,6 +161,30 @@ impl Ref<'_, MaybeFdLifecycle> {
             Lifecycle::Waiting(waker) => {
                 if !waker.will_wake(cx.waker()) {
                     *ref_mut = Lifecycle::Waiting(cx.waker().clone());
+                }
+                return Poll::Pending;
+            }
+            // Multi-CQE: first CQE arrived but still waiting for notification
+            Lifecycle::CompletedMore(_, _) => {
+                let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                match old {
+                    Lifecycle::CompletedMore(result, flags) => {
+                        *ref_mut = Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
+                    }
+                    _ => unsafe { std::hint::unreachable_unchecked() },
+                }
+                return Poll::Pending;
+            }
+            Lifecycle::WaitingMore(waker, _, _) => {
+                if !waker.will_wake(cx.waker()) {
+                    let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                    match old {
+                        Lifecycle::WaitingMore(_, result, flags) => {
+                            *ref_mut =
+                                Lifecycle::WaitingMore(cx.waker().clone(), result, flags);
+                        }
+                        _ => unsafe { std::hint::unreachable_unchecked() },
+                    }
                 }
                 return Poll::Pending;
             }
@@ -104,10 +210,28 @@ impl Ref<'_, MaybeFdLifecycle> {
                 };
                 return false;
             }
+            // Multi-CQE: still waiting for notification, must keep the slot alive
+            Lifecycle::CompletedMore(_, _) | Lifecycle::WaitingMore(_, _, _) => {
+                let old = std::mem::replace(ref_mut, Lifecycle::Submitted);
+                let boxed_data: Box<dyn std::any::Any> = if let Some(data) = data.take() {
+                    Box::new(data)
+                } else {
+                    Box::new(())
+                };
+                match old {
+                    Lifecycle::CompletedMore(_, _) | Lifecycle::WaitingMore(_, _, _) => {
+                        *ref_mut = Lifecycle::IgnoredMore(boxed_data);
+                    }
+                    _ => unsafe { std::hint::unreachable_unchecked() },
+                }
+                return false;
+            }
             Lifecycle::Completed(..) => {
                 self.remove();
             }
-            Lifecycle::Ignored(..) => unsafe { std::hint::unreachable_unchecked() },
+            Lifecycle::Ignored(..) | Lifecycle::IgnoredMore(..) => unsafe {
+                std::hint::unreachable_unchecked()
+            },
         }
         true
     }

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -260,11 +260,17 @@ impl TcpStream {
         op.wait().await
     }
 
-    /// Zero-copy write using IORING_OP_SEND_ZC (Linux 6.0+).
+    /// Attempts a zero-copy write using `IORING_OP_SEND_ZC` (Linux 6.0+).
     ///
-    /// The kernel pins the userspace buffer and DMAs directly from it,
-    /// avoiding the copy into the socket buffer. The buffer is held until
-    /// the kernel signals it is safe to release via a notification CQE.
+    /// When supported by the kernel, NIC and socket configuration, the kernel
+    /// may pin the userspace buffer and DMA directly from it, avoiding a copy
+    /// into the socket buffer. The buffer is then held until the kernel
+    /// signals it is safe to release via a notification CQE.
+    ///
+    /// In practice, `SEND_ZC` is best-effort: it may fall back to a regular
+    /// send (with copying) or fail with errors such as `EOPNOTSUPP` or
+    /// `EINVAL`. Callers should treat this like a normal write and must not
+    /// assume that a successful call always performed true zero-copy.
     ///
     /// This is most effective for large writes (e.g. 10KB+).
     #[cfg(all(target_os = "linux", feature = "iouring"))]

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -259,6 +259,19 @@ impl TcpStream {
         let op = Op::poll_write(&self.fd, relaxed).unwrap();
         op.wait().await
     }
+
+    /// Zero-copy write using IORING_OP_SEND_ZC (Linux 6.0+).
+    ///
+    /// The kernel pins the userspace buffer and DMAs directly from it,
+    /// avoiding the copy into the socket buffer. The buffer is held until
+    /// the kernel signals it is safe to release via a notification CQE.
+    ///
+    /// This is most effective for large writes (e.g. 10KB+).
+    #[cfg(all(target_os = "linux", feature = "iouring"))]
+    pub async fn write_zc<T: IoBuf>(&self, buf: T) -> BufResult<usize, T> {
+        let op = Op::send_zc(self.fd.clone(), buf).unwrap();
+        op.result().await
+    }
 }
 
 impl AsReadFd for TcpStream {

--- a/monoio/tests/send_zc.rs
+++ b/monoio/tests/send_zc.rs
@@ -1,0 +1,276 @@
+/// Tests for zero-copy send (`IORING_OP_SEND_ZC`) via `TcpStream::write_zc`.
+///
+/// `write_zc` is gated behind `#[cfg(all(target_os = "linux", feature = "iouring"))]`.
+/// On the legacy/poll-io driver the operation falls back to a regular `send(2)`,
+/// so `test_all` exercises both paths where available.
+#[cfg(all(target_os = "linux", feature = "iouring"))]
+mod send_zc_tests {
+    use monoio::{
+        buf::IoBufMut,
+        io::{AsyncReadRentExt, AsyncWriteRentExt},
+        net::{TcpListener, TcpStream},
+    };
+
+    /// Helper: bind a listener on localhost with a random port and return it
+    /// together with the bound address.
+    fn tcp_listener() -> (TcpListener, std::net::SocketAddr) {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let addr = listener.local_addr().unwrap();
+        (listener, addr)
+    }
+
+    // -- basic functionality ------------------------------------------------
+
+    /// Small message round-trip: write_zc on the client, read on the server.
+    #[monoio::test_all]
+    async fn send_zc_small_message() {
+        const MSG: &[u8] = b"hello zero-copy";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let stream = TcpStream::connect(&addr).await.unwrap();
+            let (res, _buf) = stream.write_zc(MSG.to_vec()).await;
+            assert_eq!(res.unwrap(), MSG.len());
+            drop(stream); // close connection so server read returns
+            let _ = tx.send(());
+        });
+
+        let (mut conn, _) = srv.accept().await.unwrap();
+        let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
+        let (res, buf) = conn.read_exact(buf).await;
+        res.unwrap();
+        assert_eq!(&buf.into_inner(), MSG);
+        let _ = rx.await;
+    }
+
+    /// Larger payload (64 KiB) — the size where zero-copy is most useful.
+    #[monoio::test_all]
+    async fn send_zc_large_payload() {
+        const SIZE: usize = 64 * 1024;
+        let payload: Vec<u8> = (0..SIZE).map(|i| (i % 251) as u8).collect();
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        let send_payload = payload.clone();
+        monoio::spawn(async move {
+            let stream = TcpStream::connect(&addr).await.unwrap();
+            let (res, _buf) = stream.write_zc(send_payload).await;
+            assert_eq!(res.unwrap(), SIZE);
+            drop(stream);
+            let _ = tx.send(());
+        });
+
+        let (mut conn, _) = srv.accept().await.unwrap();
+        let buf = Vec::<u8>::with_capacity(SIZE).slice_mut(0..SIZE);
+        let (res, buf) = conn.read_exact(buf).await;
+        res.unwrap();
+        assert_eq!(buf.into_inner(), payload);
+        let _ = rx.await;
+    }
+
+    // -- buffer ownership ---------------------------------------------------
+
+    /// The buffer must be returned to the caller after the write completes.
+    #[monoio::test_all]
+    async fn send_zc_returns_buffer() {
+        const MSG: &[u8] = b"buffer ownership test";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let (mut conn, _) = srv.accept().await.unwrap();
+            let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
+            let (res, _buf) = conn.read_exact(buf).await;
+            res.unwrap();
+            let _ = tx.send(());
+        });
+
+        let stream = TcpStream::connect(&addr).await.unwrap();
+        let original = MSG.to_vec();
+        let (res, returned_buf) = stream.write_zc(original).await;
+        res.unwrap();
+        // The returned buffer must still contain the original data.
+        assert_eq!(&returned_buf, MSG);
+        drop(stream);
+        let _ = rx.await;
+    }
+
+    // -- multiple sequential sends ------------------------------------------
+
+    /// Multiple consecutive `write_zc` calls on the same stream.
+    #[monoio::test_all]
+    async fn send_zc_multiple_writes() {
+        const ITER: usize = 16;
+        const MSG: &[u8] = b"repeated message\n";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let stream = TcpStream::connect(&addr).await.unwrap();
+            for _ in 0..ITER {
+                let (res, _) = stream.write_zc(MSG.to_vec()).await;
+                assert_eq!(res.unwrap(), MSG.len());
+            }
+            drop(stream);
+            let _ = tx.send(());
+        });
+
+        let (mut conn, _) = srv.accept().await.unwrap();
+        let total = ITER * MSG.len();
+        let buf = Vec::<u8>::with_capacity(total).slice_mut(0..total);
+        let (res, buf) = conn.read_exact(buf).await;
+        res.unwrap();
+        let received = buf.into_inner();
+        for chunk in received.chunks(MSG.len()) {
+            assert_eq!(chunk, MSG);
+        }
+        let _ = rx.await;
+    }
+
+    // -- zero-length send ---------------------------------------------------
+
+    /// Sending an empty buffer should succeed with 0 bytes written.
+    #[monoio::test_all]
+    async fn send_zc_empty_buffer() {
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let (conn, _) = srv.accept().await.unwrap();
+            // Keep connection alive until client is done.
+            let _ = rx.await;
+            drop(conn);
+        });
+
+        let stream = TcpStream::connect(&addr).await.unwrap();
+        let (res, buf) = stream.write_zc(Vec::<u8>::new()).await;
+        // Empty send should succeed (or return 0).
+        let n = res.unwrap();
+        assert_eq!(n, 0);
+        assert!(buf.is_empty());
+        let _ = tx.send(());
+    }
+
+    // -- echo round-trip ----------------------------------------------------
+
+    /// Full echo: client writes via write_zc, server echoes back via
+    /// regular write, client verifies received data.
+    #[monoio::test_all]
+    async fn send_zc_echo() {
+        const MSG: &[u8] = b"echo via zero-copy send";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let mut stream = TcpStream::connect(&addr).await.unwrap();
+
+            // Send via write_zc
+            let (res, _) = stream.write_zc(MSG.to_vec()).await;
+            assert_eq!(res.unwrap(), MSG.len());
+
+            // Read echo back
+            let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
+            let (res, buf) = stream.read_exact(buf).await;
+            res.unwrap();
+            assert_eq!(&buf.into_inner(), MSG);
+
+            let _ = tx.send(());
+        });
+
+        let (mut conn, _) = srv.accept().await.unwrap();
+        // Read what the client sent
+        let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
+        let (res, buf) = conn.read_exact(buf).await;
+        res.unwrap();
+        let received = buf.into_inner();
+        assert_eq!(&received, MSG);
+
+        // Echo it back with a normal write
+        let (res, _) = conn.write_all(received).await;
+        res.unwrap();
+
+        let _ = rx.await;
+    }
+
+    // -- mixed write_zc and write_all --------------------------------------
+
+    /// Interleave write_zc and regular write_all on the same stream.
+    #[monoio::test_all]
+    async fn send_zc_mixed_with_regular_write() {
+        const ZC_MSG: &[u8] = b"zero-copy-part|";
+        const REG_MSG: &[u8] = b"regular-part|";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let mut stream = TcpStream::connect(&addr).await.unwrap();
+
+            // Alternate between write_zc and write_all
+            let (res, _) = stream.write_zc(ZC_MSG.to_vec()).await;
+            assert_eq!(res.unwrap(), ZC_MSG.len());
+
+            let (res, _) = stream.write_all(REG_MSG).await;
+            res.unwrap();
+
+            let (res, _) = stream.write_zc(ZC_MSG.to_vec()).await;
+            assert_eq!(res.unwrap(), ZC_MSG.len());
+
+            let (res, _) = stream.write_all(REG_MSG).await;
+            res.unwrap();
+
+            drop(stream);
+            let _ = tx.send(());
+        });
+
+        let (mut conn, _) = srv.accept().await.unwrap();
+        let total = 2 * (ZC_MSG.len() + REG_MSG.len());
+        let buf = Vec::<u8>::with_capacity(total).slice_mut(0..total);
+        let (res, buf) = conn.read_exact(buf).await;
+        res.unwrap();
+        let received = buf.into_inner();
+
+        let mut expected = Vec::with_capacity(total);
+        for _ in 0..2 {
+            expected.extend_from_slice(ZC_MSG);
+            expected.extend_from_slice(REG_MSG);
+        }
+        assert_eq!(received, expected);
+
+        let _ = rx.await;
+    }
+
+    // -- static buffer ------------------------------------------------------
+
+    /// write_zc accepts `&'static [u8]` (which implements IoBuf).
+    #[monoio::test_all]
+    async fn send_zc_static_slice() {
+        const MSG: &[u8] = b"static slice send";
+
+        let (srv, addr) = tcp_listener();
+        let (tx, rx) = local_sync::oneshot::channel::<()>();
+
+        monoio::spawn(async move {
+            let (mut conn, _) = srv.accept().await.unwrap();
+            let buf = Vec::<u8>::with_capacity(MSG.len()).slice_mut(0..MSG.len());
+            let (res, buf) = conn.read_exact(buf).await;
+            res.unwrap();
+            assert_eq!(&buf.into_inner(), MSG);
+            let _ = tx.send(());
+        });
+
+        let stream = TcpStream::connect(&addr).await.unwrap();
+        let (res, returned) = stream.write_zc(MSG).await;
+        assert_eq!(res.unwrap(), MSG.len());
+        // The returned reference should be identical.
+        assert_eq!(returned, MSG);
+        drop(stream);
+        let _ = rx.await;
+    }
+}


### PR DESCRIPTION
## Summary

- Add support for io_uring's `SEND_ZC` and `SENDMSG_ZC` opcodes (Linux 6.0+/6.1+), enabling true zero-copy network transmission where the NIC DMAs directly from userspace buffers
- Extend the uring lifecycle state machine to handle multi-CQE operations — `SEND_ZC` produces two CQEs per submission (send result + notification), and the future only resolves after both arrive to ensure buffer safety
- Expose `TcpStream::write_zc()` public API gated behind `cfg(target_os = "linux", feature = "iouring")`

## Design

`SEND_ZC` produces two CQEs:
1. **First CQE** with `IORING_CQE_F_MORE` flag: indicates send completion (bytes sent)
2. **Second CQE** with `IORING_CQE_F_NOTIF` flag: signals the kernel has released the buffer

Three new lifecycle states handle this flow:
- `CompletedMore` — first CQE received, future hasn't polled yet
- `WaitingMore(Waker, ...)` — first CQE received, future is polling
- `IgnoredMore` — future dropped, waiting for notification before slab cleanup

Normal single-CQE operations are completely unaffected — the new states are only entered when `IORING_CQE_F_MORE` is set on a CQE.

## Test plan

- [x] `cargo check --features iouring` compiles successfully
- [x] `cargo test --features iouring` — all 82 tests pass (no regression)
- [x] Manual testing on Linux 6.0+ kernel with `SEND_ZC` capable hardware

Closes #385