### PR TITLE
Add OpenBSD support for the legacy driver

### DIFF
--- a/monoio/src/driver/op/statx.rs
+++ b/monoio/src/driver/op/statx.rs
@@ -17,9 +17,9 @@ pub(crate) struct Statx<T> {
     flags: i32,
     #[cfg(target_os = "linux")]
     statx_buf: Box<MaybeUninit<statx>>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     stat_buf: Box<MaybeUninit<libc::stat>>,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     follow_symlinks: bool,
 }
 
@@ -44,7 +44,7 @@ impl Op<FdStatx> {
         Ok(unsafe { MaybeUninit::assume_init(*complete.data.statx_buf) })
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     pub(crate) fn statx_using_fd(fd: SharedFd, follow_symlinks: bool) -> std::io::Result<Self> {
         Op::submit_with(Statx {
             inner: fd,
@@ -53,7 +53,7 @@ impl Op<FdStatx> {
         })
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     pub(crate) async fn result(self) -> std::io::Result<libc::stat> {
         let complete = self.await;
         complete.meta.result?;
@@ -100,7 +100,10 @@ impl OpAble for FdStatx {
         unimplemented!()
     }
 
-    #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "macos"))]
+    #[cfg(all(
+        any(feature = "legacy", feature = "poll-io"),
+        any(target_os = "macos", target_os = "openbsd")
+    ))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         use std::os::fd::AsRawFd;
 
@@ -133,7 +136,7 @@ impl Op<PathStatx> {
         Ok(unsafe { MaybeUninit::assume_init(*complete.data.statx_buf) })
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     pub(crate) fn statx_using_path<P: AsRef<Path>>(
         path: P,
         follow_symlinks: bool,
@@ -146,7 +149,7 @@ impl Op<PathStatx> {
         })
     }
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     pub(crate) async fn result(self) -> std::io::Result<libc::stat> {
         let complete = self.await;
         complete.meta.result?;
@@ -187,7 +190,10 @@ impl OpAble for PathStatx {
         unimplemented!()
     }
 
-    #[cfg(all(any(feature = "legacy", feature = "poll-io"), target_os = "macos"))]
+    #[cfg(all(
+        any(feature = "legacy", feature = "poll-io"),
+        any(target_os = "macos", target_os = "openbsd")
+    ))]
     fn legacy_call(&mut self) -> std::io::Result<MaybeFd> {
         if self.follow_symlinks {
             crate::syscall!(stat@NON_FD(

--- a/monoio/src/fs/file/unix.rs
+++ b/monoio/src/fs/file/unix.rs
@@ -63,7 +63,7 @@ pub(crate) async fn metadata(fd: SharedFd) -> std::io::Result<Metadata> {
     let flags = libc::AT_STATX_SYNC_AS_STAT | libc::AT_EMPTY_PATH;
     #[cfg(target_os = "linux")]
     let op = Op::statx_using_fd(fd, flags)?;
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     let op = Op::statx_using_fd(fd, true)?;
 
     op.result().await.map(FileAttr::from).map(Metadata)

--- a/monoio/src/fs/metadata/mod.rs
+++ b/monoio/src/fs/metadata/mod.rs
@@ -45,7 +45,7 @@ pub async fn metadata<P: AsRef<Path>>(path: P) -> std::io::Result<Metadata> {
     #[cfg(target_os = "linux")]
     let op = Op::statx_using_path(path, flags)?;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     let op = Op::statx_using_path(path, true)?;
 
     op.result().await.map(FileAttr::from).map(Metadata)
@@ -85,7 +85,7 @@ pub async fn symlink_metadata<P: AsRef<Path>>(path: P) -> std::io::Result<Metada
     #[cfg(target_os = "linux")]
     let op = Op::statx_using_path(path, flags)?;
 
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     let op = Op::statx_using_path(path, false)?;
 
     op.result().await.map(FileAttr::from).map(Metadata)
@@ -449,6 +449,73 @@ impl MetadataExt for Metadata {
 
     fn ctime_nsec(&self) -> i64 {
         self.0.stat.st_ctime_nsec
+    }
+
+    fn blksize(&self) -> u64 {
+        self.0.stat.st_blksize as u64
+    }
+
+    fn blocks(&self) -> u64 {
+        self.0.stat.st_blocks as u64
+    }
+}
+
+#[cfg(all(target_os = "openbsd", not(target_pointer_width = "32")))]
+impl MetadataExt for Metadata {
+    fn dev(&self) -> u64 {
+        self.0.stat.st_dev as u64
+    }
+
+    fn ino(&self) -> u64 {
+        self.0.stat.st_ino
+    }
+
+    fn mode(&self) -> u32 {
+        self.0.stat.st_mode as u32
+    }
+
+    fn nlink(&self) -> u64 {
+        self.0.stat.st_nlink as u64
+    }
+
+    fn uid(&self) -> u32 {
+        self.0.stat.st_uid
+    }
+
+    fn gid(&self) -> u32 {
+        self.0.stat.st_gid
+    }
+
+    fn rdev(&self) -> u64 {
+        self.0.stat.st_rdev as u64
+    }
+
+    fn size(&self) -> u64 {
+        self.0.stat.st_size as u64
+    }
+
+    fn atime(&self) -> i64 {
+        self.0.stat.st_atime
+    }
+
+    fn atime_nsec(&self) -> i64 {
+        self.0.stat.st_atime_nsec as i64
+    }
+
+    fn mtime(&self) -> i64 {
+        self.0.stat.st_mtime
+    }
+
+    fn mtime_nsec(&self) -> i64 {
+        self.0.stat.st_mtime_nsec as i64
+    }
+
+    fn ctime(&self) -> i64 {
+        self.0.stat.st_ctime
+    }
+
+    fn ctime_nsec(&self) -> i64 {
+        self.0.stat.st_ctime_nsec as i64
     }
 
     fn blksize(&self) -> u64 {

--- a/monoio/src/fs/metadata/unix.rs
+++ b/monoio/src/fs/metadata/unix.rs
@@ -5,7 +5,7 @@ use crate::fs::{file_type::FileType, permissions::FilePermissions};
 pub(crate) struct FileAttr {
     #[cfg(target_os = "linux")]
     pub(crate) stat: libc::stat64,
-    #[cfg(target_os = "macos")]
+    #[cfg(any(target_os = "macos", target_os = "openbsd"))]
     pub(crate) stat: libc::stat,
     #[cfg(target_os = "linux")]
     pub(crate) statx_extra_fields: Option<StatxExtraFields>,
@@ -74,7 +74,7 @@ impl From<libc::statx> for FileAttr {
     }
 }
 
-#[cfg(target_os = "macos")]
+#[cfg(any(target_os = "macos", target_os = "openbsd"))]
 impl From<libc::stat> for FileAttr {
     fn from(stat: libc::stat) -> Self {
         Self { stat }

--- a/monoio/src/net/tcp/stream.rs
+++ b/monoio/src/net/tcp/stream.rs
@@ -640,10 +640,23 @@ impl StreamMeta {
         if let Some(time) = time {
             t = t.with_time(time)
         }
+        // OpenBSD does not expose TCP keepalive interval/retries via socket2.
+        #[cfg(not(target_os = "openbsd"))]
         if let Some(interval) = interval {
             t = t.with_interval(interval)
         }
-        #[cfg(unix)]
+        #[cfg(all(
+            unix,
+            not(any(
+                target_os = "openbsd",
+                target_os = "redox",
+                target_os = "solaris",
+                target_os = "nto",
+                target_os = "espidf",
+                target_os = "vita",
+                target_os = "haiku",
+            ))
+        ))]
         if let Some(retries) = retries {
             t = t.with_retries(retries)
         }

--- a/monoio/src/net/unix/socket_addr.rs
+++ b/monoio/src/net/unix/socket_addr.rs
@@ -45,7 +45,12 @@ impl SocketAddr {
         } else if self.sockaddr.sun_path[0] == 0 {
             AddressKind::Abstract(&path[1..len])
         } else {
-            AddressKind::Pathname(OsStr::from_bytes(&path[..len - 1]).as_ref())
+            // Pathname addresses are NUL-terminated. Some platforms (notably
+            // OpenBSD) may return a socklen that covers the full sockaddr_un,
+            // including trailing padding NULs after the terminator.
+            let pathname = &path[..len];
+            let end = pathname.iter().position(|&b| b == 0).unwrap_or(pathname.len());
+            AddressKind::Pathname(OsStr::from_bytes(&pathname[..end]).as_ref())
         }
     }
 


### PR DESCRIPTION
This patch makes monoio compile and run on OpenBSD.

Tested on openbsd 7.9 arm64.